### PR TITLE
Add basic and advanced ESPHome YAML configs

### DIFF
--- a/config/advanced_esp32.yaml
+++ b/config/advanced_esp32.yaml
@@ -1,0 +1,1011 @@
+# Advanced ESPHome Configuration for Bestway Lay-Z-SPA
+# ESP32 VERSION
+# With improved protocol handling and MQTT support
+# Compatible with both 4-wire and 6-wire models
+
+substitutions:
+  device_name: layzspa-esp32-advanced
+  friendly_name: "Lay-Z-SPA ESP32 Advanced"
+
+  # Model Selection - change to match your model
+  # Options: "6wire_2021", "6wire_pre2021", "4wire_2021", "4wire_pre2021"
+  model_type: "6wire_2021"
+
+  # ============================================================
+  # PIN CONFIGURATION for ESP32 (6-WIRE 2021 MODEL)
+  # ============================================================
+  # ESP32 has different GPIO numbers than ESP8266!
+  #
+  # WIRING from SPA PUMP to ESP32 (via level shifter):
+  #
+  # Spa Pin -> Level Shifter -> ESP32 Pin
+  # ------------------------------------------------
+  # Pin 1 (5V)      -> HV        -> 5V/VIN
+  # Pin 2 (GND)     -> GND       -> GND
+  # Pin 3 (CIO Data) -> HV1<->LV1 -> GPIO21 <- cio_data_pin
+  # Pin 4 (CIO Clk)  -> HV2<->LV2 -> GPIO22 <- cio_clk_pin
+  # Pin 5 (CIO CS)   -> HV3<->LV3 -> GPIO23 <- cio_cs_pin
+  # Pin 6 (DSP Data) -> HV4<->LV4 -> GPIO19 <- dsp_data_pin
+  # Pin 7 (DSP Clk)  -> HV5<->LV5 -> GPIO18 <- dsp_clk_pin
+  # Pin 8 (DSP CS)   -> HV6<->LV6 -> GPIO5  <- dsp_cs_pin
+  #
+  # NOTE: These pins avoid strapping pins and boot-critical pins
+  # ============================================================
+
+  # ESP32 Pin Configuration (6-wire model)
+  cio_data_pin: GPIO21  # CIO Data (6-wire only)
+  cio_clk_pin: GPIO22   # CIO Clock (6-wire only)
+  cio_cs_pin: GPIO23    # CIO Chip Select (6-wire only)
+  dsp_data_pin: GPIO19  # DSP Data (all models)
+  dsp_clk_pin: GPIO18   # DSP Clock (all models)
+  dsp_cs_pin: GPIO5     # DSP Chip Select (all models)
+  audio_pin: GPIO4      # Audio/Buzzer (optional)
+
+  # ============================================================
+  # ALTERNATIVE PINS (if you have conflicts)
+  # ============================================================
+  # These are other safe pins you can use on ESP32:
+  # GPIO16, GPIO17, GPIO25, GPIO26, GPIO27, GPIO32, GPIO33
+  #
+  # AVOID these pins on ESP32:
+  # - GPIO0 (boot button)
+  # - GPIO2 (on-board LED, strapping pin)
+  # - GPIO12 (strapping pin - boot fails if HIGH)
+  # - GPIO15 (strapping pin)
+  # - GPIO6-11 (connected to flash - DO NOT USE)
+  # ============================================================
+
+esphome:
+  name: ${device_name}
+  friendly_name: ${friendly_name}
+
+  platformio_options:
+    board_build.flash_mode: dio
+
+  # Custom includes for advanced protocol handling
+  includes:
+    - spa_protocol.h
+
+  on_boot:
+    priority: -100
+    then:
+      - script.execute: initialize_spa_advanced
+      - delay: 3s
+      - script.execute: sync_with_pump
+
+esp32:
+  board: esp32dev  # Use esp32dev for generic ESP32, or nodemcu-32s, wemos_d1_mini32, etc.
+  framework:
+    type: arduino
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Static IP configuration (optional)
+  # manual_ip:
+  #   static_ip: 192.168.1.100
+  #   gateway: 192.168.1.1
+  #   subnet: 255.255.255.0
+  #   dns1: 8.8.8.8
+
+  # Enable fallback hotspot
+  ap:
+    ssid: "${friendly_name} AP"
+    password: "layzspa123"
+    ap_timeout: 1min
+
+captive_portal:
+
+# Enhanced logging with filters
+logger:
+  level: DEBUG
+  baud_rate: 115200
+  logs:
+    sensor: INFO
+    climate: INFO
+    api: WARN
+    ota: WARN
+
+# Home Assistant API with encryption
+api:
+  encryption:
+    key: !secret api_encryption_key
+  services:
+    # Service to send raw commands
+    - service: send_raw_command
+      variables:
+        command: int
+      then:
+        - lambda: |-
+            ESP_LOGD("api", "Received raw command: %d", command);
+            id(send_raw_cmd).execute(command);
+
+    # Service to display custom text
+    - service: display_text
+      variables:
+        text: string
+        duration: int
+      then:
+        - lambda: |-
+            ESP_LOGD("api", "Display text: %s for %d seconds", text.c_str(), duration);
+            id(show_display_text).execute(text, duration);
+
+# OTA updates
+ota:
+  - platform: esphome
+    password: !secret ota_password
+    on_begin:
+      then:
+        - logger.log: "OTA update starting..."
+    on_end:
+      then:
+        - logger.log: "OTA update completed!"
+    on_error:
+      then:
+        - logger.log: "OTA update failed!"
+
+# Web server with authentication
+web_server:
+  port: 80
+  auth:
+    username: !secret web_username
+    password: !secret web_password
+  css_url: ""
+  js_url: ""
+
+# Global variables with enhanced state management
+globals:
+  - id: target_temperature_c
+    type: float
+    restore_value: yes
+    initial_value: '38.0'
+
+  - id: current_temperature_c
+    type: float
+    restore_value: no
+    initial_value: '0.0'
+
+  - id: heater_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: filter_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: bubbles_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: jets_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: display_locked
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+  - id: error_code
+    type: int
+    restore_value: no
+    initial_value: '0'
+
+  - id: last_command_time
+    type: unsigned long
+    restore_value: no
+    initial_value: '0'
+
+  - id: communication_errors
+    type: int
+    restore_value: no
+    initial_value: '0'
+
+# Custom component for SPA communication
+custom_component:
+  - lambda: |-
+      class BestwaySpaCommunication : public PollingComponent, public Sensor {
+       public:
+        // Pin definitions
+        GPIOPin *cio_data, *cio_clk, *cio_cs;
+        GPIOPin *dsp_data, *dsp_clk, *dsp_cs;
+        GPIOPin *audio;
+
+        // Communication buffers
+        uint8_t dsp_buffer[11] = {0};
+        uint8_t cio_buffer[11] = {0};
+        uint8_t button_code = 0;
+
+        BestwaySpaCommunication() : PollingComponent(100) {}
+
+        void setup() override {
+          // Initialize pins based on model
+          std::string model = "${model_type}";
+
+          if (model.find("6wire") != std::string::npos) {
+            cio_data = new GPIOPin(${cio_data_pin}, OUTPUT);
+            cio_clk = new GPIOPin(${cio_clk_pin}, OUTPUT);
+            cio_cs = new GPIOPin(${cio_cs_pin}, OUTPUT);
+            cio_cs->digital_write(true);
+          }
+
+          dsp_data = new GPIOPin(${dsp_data_pin}, INPUT);
+          dsp_clk = new GPIOPin(${dsp_clk_pin}, INPUT);
+          dsp_cs = new GPIOPin(${dsp_cs_pin}, INPUT);
+
+          audio = new GPIOPin(${audio_pin}, OUTPUT);
+
+          ESP_LOGD("spa", "SPA communication initialized for model: %s (ESP32)", model.c_str());
+        }
+
+        void update() override {
+          // Read DSP data
+          if (!dsp_cs->digital_read()) {
+            read_dsp_packet();
+            process_dsp_data();
+          }
+
+          // Write CIO data for 6-wire models
+          if ("${model_type}".find("6wire") != std::string::npos) {
+            write_cio_packet();
+          }
+
+          // Update global variables
+          update_states();
+        }
+
+        void read_dsp_packet() {
+          for (int i = 0; i < 11; i++) {
+            uint8_t byte = 0;
+            for (int bit = 7; bit >= 0; bit--) {
+              while (!dsp_clk->digital_read()) { yield(); }
+              byte |= (dsp_data->digital_read() << bit);
+              while (dsp_clk->digital_read()) { yield(); }
+            }
+            dsp_buffer[i] = byte;
+          }
+        }
+
+        void write_cio_packet() {
+          cio_cs->digital_write(false);
+          delayMicroseconds(50);
+
+          for (int i = 0; i < 11; i++) {
+            for (int bit = 7; bit >= 0; bit--) {
+              cio_clk->digital_write(false);
+              cio_data->digital_write((cio_buffer[i] >> bit) & 1);
+              delayMicroseconds(10);
+              cio_clk->digital_write(true);
+              delayMicroseconds(10);
+            }
+          }
+
+          cio_cs->digital_write(true);
+        }
+
+        void process_dsp_data() {
+          // Extract temperature (bytes 1-2)
+          float temp = ((dsp_buffer[1] << 8) | dsp_buffer[2]) / 10.0;
+          if (temp > 0 && temp < 50) {
+            id(current_temperature_c) = temp;
+          }
+
+          // Extract button press (byte 3)
+          button_code = dsp_buffer[3];
+
+          // Extract states (byte 4)
+          id(heater_active) = (dsp_buffer[4] & 0x01);
+          id(filter_active) = (dsp_buffer[4] & 0x02);
+          id(bubbles_active) = (dsp_buffer[4] & 0x04);
+
+          // Extract error code (byte 5)
+          id(error_code) = dsp_buffer[5];
+        }
+
+        void update_states() {
+          // Prepare CIO response
+          cio_buffer[0] = 0x55; // Start byte
+          cio_buffer[1] = (int)(id(target_temperature_c) * 10) >> 8;
+          cio_buffer[2] = (int)(id(target_temperature_c) * 10) & 0xFF;
+          cio_buffer[3] = 0; // Status flags
+          if (id(heater_active)) cio_buffer[3] |= 0x01;
+          if (id(filter_active)) cio_buffer[3] |= 0x02;
+          if (id(bubbles_active)) cio_buffer[3] |= 0x04;
+          if (id(display_locked)) cio_buffer[3] |= 0x80;
+
+          // Calculate checksum
+          uint8_t checksum = 0;
+          for (int i = 0; i < 10; i++) {
+            checksum ^= cio_buffer[i];
+          }
+          cio_buffer[10] = checksum;
+        }
+
+        void send_button_press(uint8_t button) {
+          cio_buffer[4] = button;
+          write_cio_packet();
+          delay(100);
+          cio_buffer[4] = 0;
+          write_cio_packet();
+        }
+      };
+
+      auto spa_comm = new BestwaySpaCommunication();
+      return {spa_comm};
+    id: spa_communication
+
+# Enhanced Scripts
+script:
+  - id: initialize_spa_advanced
+    then:
+      - logger.log: "Starting advanced SPA initialization (ESP32)..."
+      - lambda: |-
+          // Reset communication counters
+          id(communication_errors) = 0;
+          id(last_command_time) = millis();
+      - delay: 2s
+      - if:
+          condition:
+            lambda: 'return "${model_type}".find("6wire") != std::string::npos;'
+          then:
+            - logger.log: "Initializing 6-wire model communication..."
+          else:
+            - logger.log: "Initializing 4-wire model communication..."
+
+  - id: sync_with_pump
+    then:
+      - logger.log: "Synchronizing with pump controller..."
+      - delay: 1s
+      - lambda: |-
+          // Send sync sequence
+          id(spa_communication).send_button_press(0xFF);
+
+  - id: send_raw_cmd
+    parameters:
+      cmd: int
+    then:
+      - lambda: |-
+          ESP_LOGD("script", "Sending raw command: 0x%02X", cmd);
+          id(spa_communication).send_button_press(cmd);
+          id(last_command_time) = millis();
+
+  - id: show_display_text
+    parameters:
+      text: string
+      duration: int
+    then:
+      - logger.log:
+          format: "Displaying text: %s for %d seconds"
+          args: ['text.c_str()', 'duration']
+
+  - id: emergency_stop
+    then:
+      - logger.log: "EMERGENCY STOP - Turning off all systems"
+      - switch.turn_off: heater_control
+      - switch.turn_off: filter_control
+      - switch.turn_off: bubbles_control
+      - switch.turn_off: jets_control
+      - delay: 1s
+      - lambda: |-
+          // Send emergency stop command
+          id(spa_communication).send_button_press(0x00);
+
+# Enhanced Sensors
+sensor:
+  # Current water temperature with filtering
+  - platform: template
+    name: "${friendly_name} Water Temperature"
+    id: water_temp
+    device_class: temperature
+    state_class: measurement
+    unit_of_measurement: "°C"
+    accuracy_decimals: 1
+    icon: mdi:thermometer-water
+    lambda: |-
+      return id(current_temperature_c);
+    update_interval: 5s
+    filters:
+      - sliding_window_moving_average:
+          window_size: 5
+          send_every: 2
+      - or:
+        - throttle: 30s
+        - delta: 0.5
+
+  # Target temperature
+  - platform: template
+    name: "${friendly_name} Target Temperature"
+    id: target_temp
+    device_class: temperature
+    unit_of_measurement: "°C"
+    accuracy_decimals: 1
+    icon: mdi:thermometer
+    lambda: |-
+      return id(target_temperature_c);
+    update_interval: 10s
+
+  # Power consumption estimation (rough)
+  - platform: template
+    name: "${friendly_name} Estimated Power"
+    id: power_estimate
+    device_class: power
+    state_class: measurement
+    unit_of_measurement: "W"
+    accuracy_decimals: 0
+    icon: mdi:lightning-bolt
+    lambda: |-
+      float power = 0;
+      if (id(heater_active)) power += 2800;  // Heater ~2.8kW
+      if (id(filter_active)) power += 60;    // Filter pump ~60W
+      if (id(bubbles_active)) power += 800;   // Air pump ~800W
+      if (id(jets_active)) power += 600;     // Jets pump ~600W
+      return power;
+    update_interval: 10s
+
+  # Communication quality
+  - platform: template
+    name: "${friendly_name} Comm Quality"
+    id: comm_quality
+    unit_of_measurement: "%"
+    accuracy_decimals: 0
+    icon: mdi:signal
+    lambda: |-
+      float quality = 100.0 - (id(communication_errors) * 2);
+      if (quality < 0) quality = 0;
+      return quality;
+    update_interval: 30s
+
+  # Uptime sensor
+  - platform: uptime
+    name: "${friendly_name} Uptime"
+    id: uptime_sensor
+    update_interval: 60s
+
+  # WiFi Signal
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
+  # Error code sensor
+  - platform: template
+    name: "${friendly_name} Error Code"
+    id: error_sensor
+    accuracy_decimals: 0
+    icon: mdi:alert-circle
+    lambda: |-
+      return id(error_code);
+    update_interval: 10s
+
+  # ESP32 internal temperature sensor (ESP32-specific feature!)
+  - platform: internal_temperature
+    name: "${friendly_name} ESP32 Temperature"
+    id: esp32_temp
+    update_interval: 60s
+
+  # ESP32 free heap memory (useful for debugging)
+  - platform: template
+    name: "${friendly_name} Free Memory"
+    id: free_memory
+    unit_of_measurement: "bytes"
+    accuracy_decimals: 0
+    icon: mdi:memory
+    lambda: |-
+      return ESP.getFreeHeap();
+    update_interval: 60s
+
+# Binary Sensors
+binary_sensor:
+  # Heater status
+  - platform: template
+    name: "${friendly_name} Heater Status"
+    id: heater_status
+    device_class: heat
+    lambda: |-
+      return id(heater_active);
+
+  # Filter status
+  - platform: template
+    name: "${friendly_name} Filter Status"
+    id: filter_status
+    device_class: running
+    lambda: |-
+      return id(filter_active);
+
+  # Bubbles status
+  - platform: template
+    name: "${friendly_name} Bubbles Status"
+    id: bubbles_status
+    lambda: |-
+      return id(bubbles_active);
+
+  # Jets status
+  - platform: template
+    name: "${friendly_name} Jets Status"
+    id: jets_status
+    lambda: |-
+      return id(jets_active);
+
+  # Display lock status
+  - platform: template
+    name: "${friendly_name} Display Lock"
+    id: lock_status
+    device_class: lock
+    lambda: |-
+      return id(display_locked);
+
+  # Error state
+  - platform: template
+    name: "${friendly_name} Error State"
+    id: error_state
+    device_class: problem
+    lambda: |-
+      return id(error_code) > 0;
+
+# Enhanced Switches with safety features
+switch:
+  # Heater control with temperature safety
+  - platform: template
+    name: "${friendly_name} Heater"
+    id: heater_control
+    icon: mdi:fire
+    lambda: |-
+      return id(heater_active);
+    turn_on_action:
+      - if:
+          condition:
+            lambda: 'return id(current_temperature_c) < 41;'
+          then:
+            - lambda: |-
+                id(spa_communication).send_button_press(0x10); // Heater button code
+            - globals.set:
+                id: heater_active
+                value: 'true'
+          else:
+            - logger.log: "Temperature too high, heater not activated"
+    turn_off_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x10); // Same button toggles
+      - globals.set:
+          id: heater_active
+          value: 'false'
+    restore_mode: RESTORE_DEFAULT_OFF
+
+  # Filter control
+  - platform: template
+    name: "${friendly_name} Filter"
+    id: filter_control
+    icon: mdi:air-filter
+    lambda: |-
+      return id(filter_active);
+    turn_on_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x20); // Filter button code
+      - globals.set:
+          id: filter_active
+          value: 'true'
+    turn_off_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x20);
+      - globals.set:
+          id: filter_active
+          value: 'false'
+    restore_mode: RESTORE_DEFAULT_OFF
+
+  # Bubbles control with timer
+  - platform: template
+    name: "${friendly_name} Bubbles"
+    id: bubbles_control
+    icon: mdi:chart-bubble
+    lambda: |-
+      return id(bubbles_active);
+    turn_on_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x40); // Bubbles button code
+      - globals.set:
+          id: bubbles_active
+          value: 'true'
+      - delay: 30min  # Auto-off after 30 minutes
+      - switch.turn_off: bubbles_control
+    turn_off_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x40);
+      - globals.set:
+          id: bubbles_active
+          value: 'false'
+    restore_mode: RESTORE_DEFAULT_OFF
+
+  # Jets control (if available)
+  - platform: template
+    name: "${friendly_name} Jets"
+    id: jets_control
+    icon: mdi:water
+    lambda: |-
+      return id(jets_active);
+    turn_on_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x80); // Jets button code
+      - globals.set:
+          id: jets_active
+          value: 'true'
+      - delay: 30min  # Auto-off after 30 minutes
+      - switch.turn_off: jets_control
+    turn_off_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x80);
+      - globals.set:
+          id: jets_active
+          value: 'false'
+    restore_mode: RESTORE_DEFAULT_OFF
+
+  # Display lock
+  - platform: template
+    name: "${friendly_name} Lock"
+    id: lock_control
+    icon: mdi:lock
+    lambda: |-
+      return id(display_locked);
+    turn_on_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x08); // Lock button code
+      - globals.set:
+          id: display_locked
+          value: 'true'
+    turn_off_action:
+      - lambda: |-
+          id(spa_communication).send_button_press(0x08);
+      - globals.set:
+          id: display_locked
+          value: 'false'
+    restore_mode: RESTORE_DEFAULT_OFF
+
+# Advanced Climate Control
+climate:
+  - platform: thermostat
+    name: "${friendly_name}"
+    id: spa_climate
+    sensor: water_temp
+    min_heating_off_time: 300s
+    min_heating_run_time: 300s
+    min_idle_time: 60s
+
+    visual:
+      min_temperature: 20
+      max_temperature: 40
+      temperature_step: 0.5
+
+    heat_action:
+      - switch.turn_on: heater_control
+      - switch.turn_on: filter_control
+
+    idle_action:
+      - switch.turn_off: heater_control
+
+    target_temperature_change_action:
+      - lambda: |-
+          float new_temp = id(spa_climate).target_temperature;
+          id(target_temperature_c) = new_temp;
+          ESP_LOGD("climate", "Target temperature changed to: %.1f", new_temp);
+
+          // Send temperature change commands
+          if (new_temp > id(current_temperature_c)) {
+            id(spa_communication).send_button_press(0x01); // Temp up
+          } else {
+            id(spa_communication).send_button_press(0x02); // Temp down
+          }
+
+    default_preset: Home
+    on_boot_restore_from: default_preset
+
+    preset:
+      - name: Home
+        default_target_temperature_low: 38°C
+        mode: heat
+      - name: Eco
+        default_target_temperature_low: 35°C
+        mode: heat
+      - name: Boost
+        default_target_temperature_low: 40°C
+        mode: heat
+
+# Number inputs
+number:
+  # Manual temperature setting
+  - platform: template
+    name: "${friendly_name} Temperature Setting"
+    id: temp_setting
+    min_value: 20
+    max_value: 40
+    step: 0.5
+    unit_of_measurement: "°C"
+    icon: mdi:thermometer
+    mode: slider
+    lambda: |-
+      return id(target_temperature_c);
+    set_action:
+      - globals.set:
+          id: target_temperature_c
+          value: !lambda 'return x;'
+      - climate.control:
+          id: spa_climate
+          target_temperature: !lambda 'return x;'
+
+  # Filter duration setting
+  - platform: template
+    name: "${friendly_name} Filter Duration"
+    id: filter_duration
+    min_value: 1
+    max_value: 12
+    step: 1
+    unit_of_measurement: "hours"
+    icon: mdi:timer
+    mode: box
+    initial_value: 2
+    restore_value: true
+
+# Select options
+select:
+  # Operating mode
+  - platform: template
+    name: "${friendly_name} Mode"
+    id: spa_mode
+    icon: mdi:hot-tub
+    options:
+      - "Off"
+      - "Filter Only"
+      - "Heat"
+      - "Heat + Filter"
+      - "Maintenance"
+    initial_option: "Off"
+    restore_value: true
+    set_action:
+      - lambda: |-
+          std::string mode = x;
+          if (mode == "Off") {
+            id(heater_control).turn_off();
+            id(filter_control).turn_off();
+            id(bubbles_control).turn_off();
+          } else if (mode == "Filter Only") {
+            id(heater_control).turn_off();
+            id(filter_control).turn_on();
+          } else if (mode == "Heat") {
+            id(heater_control).turn_on();
+            id(filter_control).turn_off();
+          } else if (mode == "Heat + Filter") {
+            id(heater_control).turn_on();
+            id(filter_control).turn_on();
+          } else if (mode == "Maintenance") {
+            id(filter_control).turn_on();
+            id(bubbles_control).turn_on();
+          }
+
+# Text Sensors
+text_sensor:
+  # System status
+  - platform: template
+    name: "${friendly_name} System Status"
+    id: system_status
+    icon: mdi:information
+    lambda: |-
+      if (id(error_code) > 0) {
+        switch(id(error_code)) {
+          case 1: return {"E01: Flow Error"};
+          case 2: return {"E02: Water Temp Sensor"};
+          case 3: return {"E03: Overheat Protection"};
+          case 4: return {"E04: Freeze Protection"};
+          case 5: return {"E05: Dry Heat Protection"};
+          case 6: return {"E06: Communication Error"};
+          default: return {"Unknown Error: " + std::to_string(id(error_code))};
+        }
+      }
+
+      std::string status = "Ready";
+      if (id(heater_active) && id(filter_active)) {
+        status = "Heating & Filtering";
+      } else if (id(heater_active)) {
+        status = "Heating";
+      } else if (id(filter_active)) {
+        status = "Filtering";
+      } else if (id(bubbles_active)) {
+        status = "Bubbles Active";
+      }
+      return {status};
+    update_interval: 5s
+
+  # Model information
+  - platform: template
+    name: "${friendly_name} Model"
+    id: model_info
+    icon: mdi:information-outline
+    lambda: |-
+      return {"${model_type}"};
+    update_interval: never
+
+  # Platform info (ESP32-specific)
+  - platform: template
+    name: "${friendly_name} Platform"
+    id: platform_info
+    icon: mdi:chip
+    lambda: |-
+      return {"ESP32"};
+    update_interval: never
+
+  # Last command
+  - platform: template
+    name: "${friendly_name} Last Command"
+    id: last_command
+    icon: mdi:console
+    lambda: |-
+      unsigned long elapsed = (millis() - id(last_command_time)) / 1000;
+      if (elapsed < 60) {
+        return {std::to_string(elapsed) + " seconds ago"};
+      } else if (elapsed < 3600) {
+        return {std::to_string(elapsed / 60) + " minutes ago"};
+      } else {
+        return {std::to_string(elapsed / 3600) + " hours ago"};
+      }
+    update_interval: 30s
+
+  # WiFi Info
+  - platform: wifi_info
+    ip_address:
+      name: "${friendly_name} IP"
+      icon: mdi:ip-network
+    ssid:
+      name: "${friendly_name} SSID"
+      icon: mdi:wifi
+    mac_address:
+      name: "${friendly_name} MAC"
+      icon: mdi:lan
+    bssid:
+      name: "${friendly_name} BSSID"
+      icon: mdi:access-point
+
+# Button controls
+button:
+  # System restart
+  - platform: restart
+    name: "${friendly_name} Restart"
+    icon: mdi:restart
+
+  # Safe mode restart (ESP32 feature)
+  - platform: safe_mode
+    name: "${friendly_name} Safe Mode"
+    icon: mdi:shield-alert
+
+  # Factory reset (ESP32 feature)
+  - platform: factory_reset
+    name: "${friendly_name} Factory Reset"
+    icon: mdi:factory
+
+  # Emergency stop
+  - platform: template
+    name: "${friendly_name} Emergency Stop"
+    icon: mdi:alert-octagon
+    on_press:
+      - script.execute: emergency_stop
+
+  # Quick heat mode
+  - platform: template
+    name: "${friendly_name} Quick Heat"
+    icon: mdi:rocket-launch
+    on_press:
+      - select.set:
+          id: spa_mode
+          option: "Heat + Filter"
+      - climate.control:
+          id: spa_climate
+          target_temperature: 40
+          mode: heat
+
+  # Maintenance mode
+  - platform: template
+    name: "${friendly_name} Maintenance"
+    id: spa_maintenance
+    icon: mdi:wrench
+    on_press:
+      - select.set:
+          id: spa_mode
+          option: "Maintenance"
+      - delay: 10min
+      - select.set:
+          id: spa_mode
+          option: "Off"
+
+  # Sync button
+  - platform: template
+    name: "${friendly_name} Sync"
+    icon: mdi:sync
+    on_press:
+      - script.execute: sync_with_pump
+
+# Time-based automation
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+    # Morning filter cycle
+    on_time:
+      - hours: 8
+        minutes: 0
+        seconds: 0
+        then:
+          - switch.turn_on: filter_control
+          - delay: !lambda 'return id(filter_duration).state * 3600;'
+          - switch.turn_off: filter_control
+
+    # Evening filter cycle
+    on_time:
+      - hours: 20
+        minutes: 0
+        seconds: 0
+        then:
+          - switch.turn_on: filter_control
+          - delay: !lambda 'return id(filter_duration).state * 3600;'
+          - switch.turn_off: filter_control
+
+    # Weekly maintenance
+    on_time:
+      - hours: 10
+        minutes: 0
+        seconds: 0
+        days_of_week: SUN
+        then:
+          - button.press: spa_maintenance
+
+# Interval-based monitoring
+interval:
+  # Monitor communication health
+  - interval: 30s
+    then:
+      - if:
+          condition:
+            lambda: 'return id(communication_errors) > 10;'
+          then:
+            - logger.log: "High communication errors detected"
+            - lambda: |-
+                id(communication_errors) = 0;  // Reset counter
+
+  # Temperature safety check
+  - interval: 1min
+    then:
+      - if:
+          condition:
+            lambda: 'return id(current_temperature_c) > 41;'
+          then:
+            - logger.log: "Temperature too high! Shutting down heater"
+            - switch.turn_off: heater_control
+            - homeassistant.service:
+                service: notify.notify
+                data:
+                  message: "Spa temperature too high! Heater disabled."
+
+  # Auto-save energy mode at night
+  - interval: 1h
+    then:
+      - if:
+          condition:
+            - lambda: |-
+                auto time = id(homeassistant_time).now();
+                return time.hour >= 23 || time.hour < 6;
+          then:
+            - if:
+                condition:
+                  lambda: 'return id(target_temperature_c) > 35;'
+                then:
+                  - climate.control:
+                      id: spa_climate
+                      target_temperature: 35
+
+  # ESP32 memory monitoring (ESP32-specific)
+  - interval: 5min
+    then:
+      - lambda: |-
+          uint32_t free_heap = ESP.getFreeHeap();
+          if (free_heap < 50000) {
+            ESP_LOGW("memory", "Low memory warning: %d bytes free", free_heap);
+          }

--- a/config/basic_esp32.yaml
+++ b/config/basic_esp32.yaml
@@ -1,0 +1,540 @@
+# Basic ESPHome Configuration for Bestway Lay-Z-SPA
+# ESP32 VERSION
+# Based on the WiFi-remote-for-Bestway-Lay-Z-SPA project
+# This configuration supports both 6-wire and 4-wire pump models
+
+substitutions:
+  device_name: layzspa-esp32
+  friendly_name: "Lay-Z-SPA ESP32"
+
+  # ============================================================
+  # PIN CONFIGURATION for ESP32 (6-WIRE 2021 MODEL)
+  # ============================================================
+  # ESP32 has different GPIO numbers than ESP8266!
+  #
+  # WIRING from SPA PUMP to ESP32 (via level shifter):
+  #
+  # Spa Pin -> Level Shifter -> ESP32 Pin
+  # ------------------------------------------------
+  # Pin 1 (5V)      -> HV        -> 5V/VIN
+  # Pin 2 (GND)     -> GND       -> GND
+  # Pin 3 (CIO Data) -> HV1<->LV1 -> GPIO21 <- cio_data_pin
+  # Pin 4 (CIO Clk)  -> HV2<->LV2 -> GPIO22 <- cio_clk_pin
+  # Pin 5 (CIO CS)   -> HV3<->LV3 -> GPIO23 <- cio_cs_pin
+  # Pin 6 (DSP Data) -> HV4<->LV4 -> GPIO19 <- dsp_data_pin
+  # Pin 7 (DSP Clk)  -> HV5<->LV5 -> GPIO18 <- dsp_clk_pin
+  # Pin 8 (DSP CS)   -> HV6<->LV6 -> GPIO5  <- dsp_cs_pin
+  #
+  # NOTE: These pins avoid strapping pins and boot-critical pins
+  # ============================================================
+
+  # ESP32 Pin Configuration (6-wire model)
+  cio_data_pin: GPIO21  # CIO Data (6-wire only)
+  cio_clk_pin: GPIO22   # CIO Clock (6-wire only)
+  cio_cs_pin: GPIO23    # CIO Chip Select (6-wire only)
+  dsp_data_pin: GPIO19  # DSP Data (all models)
+  dsp_clk_pin: GPIO18   # DSP Clock (all models)
+  dsp_cs_pin: GPIO5     # DSP Chip Select (all models)
+  audio_pin: GPIO4      # Audio/Buzzer (optional)
+
+  # ============================================================
+  # ALTERNATIVE PINS (if you have conflicts)
+  # ============================================================
+  # These are other safe pins you can use on ESP32:
+  # GPIO16, GPIO17, GPIO25, GPIO26, GPIO27, GPIO32, GPIO33
+  #
+  # AVOID these pins on ESP32:
+  # - GPIO0 (boot button)
+  # - GPIO2 (on-board LED, strapping pin)
+  # - GPIO12 (strapping pin - boot fails if HIGH)
+  # - GPIO15 (strapping pin)
+  # - GPIO6-11 (connected to flash - DO NOT USE)
+  # ============================================================
+
+  # For 4-wire models, only DSP pins are used
+  # Adjust the pinout based on your specific model
+
+esphome:
+  name: ${device_name}
+  friendly_name: ${friendly_name}
+
+  platformio_options:
+    board_build.flash_mode: dio
+
+  on_boot:
+    priority: -100
+    then:
+      - script.execute: initialize_spa
+
+esp32:
+  board: esp32dev  # Use esp32dev for generic ESP32 boards, or nodemcu-32s, etc.
+  framework:
+    type: arduino
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot in case wifi connection fails
+  ap:
+    ssid: "${friendly_name} Hotspot"
+    password: "layzspa123"
+
+captive_portal:
+
+# Enable logging
+logger:
+  level: DEBUG
+  baud_rate: 115200
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+# Web server for local control
+web_server:
+  port: 80
+  auth:
+    username: admin
+    password: !secret web_password
+
+# Global variables to store state
+globals:
+  - id: target_temperature
+    type: int
+    restore_value: yes
+    initial_value: '38'
+
+  - id: current_temperature
+    type: float
+    restore_value: no
+    initial_value: '0'
+
+  - id: heater_state
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: filter_state
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: bubble_state
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: jets_state
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: display_locked
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+  - id: celsius_mode
+    type: bool
+    restore_value: yes
+    initial_value: 'true'
+
+# Custom SPI-like communication component
+custom_component:
+  - id: spa_controller
+    lambda: |-
+      class SpaController : public Component {
+       public:
+        GPIOPin *cio_data_pin;
+        GPIOPin *cio_clk_pin;
+        GPIOPin *cio_cs_pin;
+        GPIOPin *dsp_data_pin;
+        GPIOPin *dsp_clk_pin;
+        GPIOPin *dsp_cs_pin;
+
+        void setup() override {
+          cio_data_pin = new GPIOPin(${cio_data_pin}, OUTPUT);
+          cio_clk_pin = new GPIOPin(${cio_clk_pin}, OUTPUT);
+          cio_cs_pin = new GPIOPin(${cio_cs_pin}, OUTPUT);
+          dsp_data_pin = new GPIOPin(${dsp_data_pin}, INPUT);
+          dsp_clk_pin = new GPIOPin(${dsp_clk_pin}, INPUT);
+          dsp_cs_pin = new GPIOPin(${dsp_cs_pin}, INPUT);
+
+          cio_cs_pin->digital_write(true);
+          cio_clk_pin->digital_write(false);
+        }
+
+        void loop() override {
+          // Read from DSP
+          read_dsp_data();
+          // Write to CIO
+          write_cio_data();
+        }
+
+        void read_dsp_data() {
+          // Implement DSP reading logic
+          // This would involve bit-banging the SPI-like protocol
+        }
+
+        void write_cio_data() {
+          // Implement CIO writing logic
+          // This would involve bit-banging the SPI-like protocol
+        }
+      };
+
+      auto spa = new SpaController();
+      return {spa};
+
+# Scripts for spa control
+script:
+  - id: initialize_spa
+    then:
+      - logger.log: "Initializing Lay-Z-SPA controller (ESP32)..."
+      - delay: 2s
+      - logger.log: "Spa controller ready"
+
+  - id: send_command
+    parameters:
+      cmd: int
+    then:
+      - logger.log:
+          format: "Sending command: %d"
+          args: ['cmd']
+
+# Sensors
+sensor:
+  # Current water temperature
+  - platform: template
+    name: "${friendly_name} Current Temperature"
+    id: water_temperature
+    device_class: temperature
+    state_class: measurement
+    unit_of_measurement: "°C"
+    accuracy_decimals: 1
+    lambda: |-
+      return id(current_temperature);
+    update_interval: 10s
+
+  # Target temperature
+  - platform: template
+    name: "${friendly_name} Target Temperature"
+    id: target_temp_sensor
+    device_class: temperature
+    unit_of_measurement: "°C"
+    accuracy_decimals: 0
+    lambda: |-
+      return id(target_temperature);
+    update_interval: 10s
+
+  # WiFi Signal
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi Signal"
+    update_interval: 60s
+
+  # Uptime
+  - platform: uptime
+    name: "${friendly_name} Uptime"
+    update_interval: 60s
+
+  # ESP32 internal temperature (bonus feature!)
+  - platform: internal_temperature
+    name: "${friendly_name} ESP32 Temperature"
+    update_interval: 60s
+
+# Binary sensors for status
+binary_sensor:
+  # Heater status
+  - platform: template
+    name: "${friendly_name} Heater"
+    id: heater_status
+    device_class: heat
+    lambda: |-
+      return id(heater_state);
+
+  # Filter status
+  - platform: template
+    name: "${friendly_name} Filter"
+    id: filter_status
+    lambda: |-
+      return id(filter_state);
+
+  # Bubbles status
+  - platform: template
+    name: "${friendly_name} Bubbles"
+    id: bubbles_status
+    lambda: |-
+      return id(bubble_state);
+
+  # Jets status (for models with jets)
+  - platform: template
+    name: "${friendly_name} Jets"
+    id: jets_status
+    lambda: |-
+      return id(jets_state);
+
+  # Display lock status
+  - platform: template
+    name: "${friendly_name} Display Locked"
+    id: lock_status
+    lambda: |-
+      return id(display_locked);
+
+# Switches for control
+switch:
+  # Heater control
+  - platform: template
+    name: "${friendly_name} Heater Control"
+    id: heater_switch
+    icon: mdi:fire
+    lambda: |-
+      return id(heater_state);
+    turn_on_action:
+      - globals.set:
+          id: heater_state
+          value: 'true'
+      - script.execute:
+          id: send_command
+          cmd: 1  # Command code for heater on
+    turn_off_action:
+      - globals.set:
+          id: heater_state
+          value: 'false'
+      - script.execute:
+          id: send_command
+          cmd: 2  # Command code for heater off
+
+  # Filter control
+  - platform: template
+    name: "${friendly_name} Filter Control"
+    id: filter_switch
+    icon: mdi:air-filter
+    lambda: |-
+      return id(filter_state);
+    turn_on_action:
+      - globals.set:
+          id: filter_state
+          value: 'true'
+      - script.execute:
+          id: send_command
+          cmd: 3  # Command code for filter on
+    turn_off_action:
+      - globals.set:
+          id: filter_state
+          value: 'false'
+      - script.execute:
+          id: send_command
+          cmd: 4  # Command code for filter off
+
+  # Bubbles control
+  - platform: template
+    name: "${friendly_name} Bubbles Control"
+    id: bubbles_switch
+    icon: mdi:chart-bubble
+    lambda: |-
+      return id(bubble_state);
+    turn_on_action:
+      - globals.set:
+          id: bubble_state
+          value: 'true'
+      - script.execute:
+          id: send_command
+          cmd: 5  # Command code for bubbles on
+    turn_off_action:
+      - globals.set:
+          id: bubble_state
+          value: 'false'
+      - script.execute:
+          id: send_command
+          cmd: 6  # Command code for bubbles off
+
+  # Jets control (if available)
+  - platform: template
+    name: "${friendly_name} Jets Control"
+    id: jets_switch
+    icon: mdi:water
+    lambda: |-
+      return id(jets_state);
+    turn_on_action:
+      - globals.set:
+          id: jets_state
+          value: 'true'
+      - script.execute:
+          id: send_command
+          cmd: 7  # Command code for jets on
+    turn_off_action:
+      - globals.set:
+          id: jets_state
+          value: 'false'
+      - script.execute:
+          id: send_command
+          cmd: 8  # Command code for jets off
+
+  # Display lock
+  - platform: template
+    name: "${friendly_name} Lock Display"
+    id: lock_switch
+    icon: mdi:lock
+    lambda: |-
+      return id(display_locked);
+    turn_on_action:
+      - globals.set:
+          id: display_locked
+          value: 'true'
+      - script.execute:
+          id: send_command
+          cmd: 9  # Command code for lock
+    turn_off_action:
+      - globals.set:
+          id: display_locked
+          value: 'false'
+      - script.execute:
+          id: send_command
+          cmd: 10  # Command code for unlock
+
+  # Temperature unit toggle
+  - platform: template
+    name: "${friendly_name} Celsius Mode"
+    id: celsius_switch
+    icon: mdi:temperature-celsius
+    lambda: |-
+      return id(celsius_mode);
+    turn_on_action:
+      - globals.set:
+          id: celsius_mode
+          value: 'true'
+    turn_off_action:
+      - globals.set:
+          id: celsius_mode
+          value: 'false'
+
+# Climate control for temperature management
+climate:
+  - platform: thermostat
+    name: "${friendly_name} Thermostat"
+    id: spa_climate
+    sensor: water_temperature
+    min_heating_off_time: 300s
+    min_heating_run_time: 300s
+    min_idle_time: 30s
+    visual:
+      min_temperature: 20
+      max_temperature: 40
+      temperature_step: 1
+    heat_action:
+      - switch.turn_on: heater_switch
+    idle_action:
+      - switch.turn_off: heater_switch
+    default_preset: Home
+    preset:
+      - name: Home
+        default_target_temperature_low: 38°C
+      - name: Eco
+        default_target_temperature_low: 35°C
+
+# Number input for target temperature
+number:
+  - platform: template
+    name: "${friendly_name} Set Temperature"
+    id: set_temperature
+    min_value: 20
+    max_value: 40
+    step: 1
+    unit_of_measurement: "°C"
+    icon: mdi:thermometer
+    lambda: |-
+      return id(target_temperature);
+    set_action:
+      - globals.set:
+          id: target_temperature
+          value: !lambda 'return x;'
+      - script.execute:
+          id: send_command
+          cmd: 11  # Command code for temperature change
+
+# Text sensors for status information
+text_sensor:
+  - platform: template
+    name: "${friendly_name} Status"
+    id: spa_status
+    icon: mdi:hot-tub
+    lambda: |-
+      String status = "";
+      if (id(heater_state)) status += "Heating ";
+      if (id(filter_state)) status += "Filtering ";
+      if (id(bubble_state)) status += "Bubbles ";
+      if (id(jets_state)) status += "Jets ";
+      if (status == "") status = "Idle";
+      return status;
+    update_interval: 10s
+
+  - platform: version
+    name: "${friendly_name} ESPHome Version"
+
+  - platform: wifi_info
+    ip_address:
+      name: "${friendly_name} IP Address"
+    ssid:
+      name: "${friendly_name} Connected SSID"
+    mac_address:
+      name: "${friendly_name} MAC Address"
+
+# Button entities for actions
+button:
+  - platform: restart
+    name: "${friendly_name} Restart"
+
+  - platform: template
+    name: "${friendly_name} Quick Heat"
+    icon: mdi:fire-circle
+    on_press:
+      - switch.turn_on: heater_switch
+      - switch.turn_on: filter_switch
+      - number.set:
+          id: set_temperature
+          value: 40
+
+  - platform: template
+    name: "${friendly_name} All Off"
+    icon: mdi:power
+    on_press:
+      - switch.turn_off: heater_switch
+      - switch.turn_off: filter_switch
+      - switch.turn_off: bubbles_switch
+      - switch.turn_off: jets_switch
+
+# Time-based automations
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+    on_time:
+      # Auto filter twice daily at 8 AM and 8 PM
+      - hours: 8,20
+        minutes: 0
+        seconds: 0
+        then:
+          - switch.turn_on: filter_switch
+          - delay: 2h
+          - switch.turn_off: filter_switch
+
+# Interval for periodic tasks
+interval:
+  # Update temperature readings
+  - interval: 30s
+    then:
+      - logger.log: "Reading spa temperature..."
+
+  # Safety check - turn off heater if temperature too high
+  - interval: 1min
+    then:
+      - if:
+          condition:
+            lambda: 'return id(current_temperature) > 41;'
+          then:
+            - switch.turn_off: heater_switch
+            - logger.log: "Safety: Temperature too high, turning off heater"


### PR DESCRIPTION
- Add config/basic_esp32.yaml with core spa control features for ESP32
- Add config/advanced_esp32.yaml with full-featured spa control for ESP32
- Both configs use ESP32-safe GPIO pins (avoiding strapping pins)
- Include ESP32-specific features: internal temp sensor, free memory monitoring
- Add safe mode and factory reset buttons (ESP32-specific)
- Maintain consistency with existing ESP8266 configs