### PR TITLE
Fix duplicate ota_password key in config

### DIFF
--- a/config/secrets.yaml.template
+++ b/config/secrets.yaml.template
@@ -1,0 +1,17 @@
+# ESPHome Bestway LaySpa Secrets Template
+# Copy this file to secrets.yaml and fill in your values
+# IMPORTANT: Do not define any key more than once!
+
+# WiFi credentials
+wifi_ssid: "your_wifi_network_name"
+wifi_password: "your_wifi_password"
+
+# API encryption key (generate a random 32-byte base64 string)
+# You can generate one at: https://esphome.io/components/api.html
+api_encryption_key: "your_base64_encryption_key_here"
+
+# OTA (Over-The-Air) update password
+ota_password: "your_ota_password"
+
+# Optional: Fallback hotspot password (for when WiFi is unavailable)
+fallback_password: "your_fallback_hotspot_password"


### PR DESCRIPTION
The template now includes clear comments and all required secret keys, helping users avoid accidentally defining keys like ota_password twice.