### PR TITLE
Implement complete 6-wire protocol from reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,165 +1,238 @@
 # Bestway Lay-Z-Spa ESPHome Firmware
 
-**Native ESPHome firmware replacement for Bestway spas using Visualapproach hardware.**
+**Native ESPHome firmware for Bestway spas using VisualApproach hardware.**
 
-This completely replaces the Visualapproach firmware with pure ESPHome, giving you native Home Assistant integration with no MQTT broker needed.
+This completely replaces the VisualApproach firmware with pure ESPHome, giving you native Home Assistant integration with no MQTT broker needed.
 
 ## Overview
 
 ```
-[Bestway Spa] ←serial→ [ESP8266 + ESPHome + This Component] ←API→ [Home Assistant]
+[Bestway Spa] ←serial/SPI→ [ESP8266 + ESPHome] ←API→ [Home Assistant]
 ```
 
-**You keep the existing Visualapproach PCB hardware** (level shifters, connectors, etc.) but replace the firmware with this ESPHome implementation.
+**You keep the existing VisualApproach PCB hardware** (level shifters, connectors, etc.) but replace the firmware with this ESPHome implementation.
 
-## Why Replace Visualapproach Firmware?
+## Why Replace VisualApproach Firmware?
 
-✅ **Simpler** - No MQTT broker needed  
-✅ **Faster** - Direct Home Assistant API  
-✅ **Cleaner** - Native ESPHome component, not custom firmware  
-✅ **Better integration** - Automatic discovery, services, automations  
-✅ **OTA updates** - Update from Home Assistant UI  
-✅ **More reliable** - ESPHome's proven stability  
+- **Simpler** - No MQTT broker needed
+- **Faster** - Direct Home Assistant API
+- **Cleaner** - Native ESPHome component
+- **Better integration** - Automatic discovery, services, automations
+- **OTA updates** - Update from Home Assistant UI
+- **More reliable** - ESPHome's proven stability
 
 ## Features
 
 ### Climate Entity
-- Full thermostat control
-- Temperature display (current & target)
-- Heat/Fan/Off modes
-- Heating action status
+- Full thermostat control with temperature display (current & target)
+- Heat/Fan/Off modes with heating action status
 
 ### Switches
+- Power on/off
 - Heater on/off
 - Filter pump on/off
 - Air bubbles on/off
+- Hydrojets on/off (model-dependent)
 - Child lock
 
 ### Sensors
 - Current temperature (with smoothing)
 - Target temperature
+- Power status (binary)
 - Heating status (binary)
 - Filter running (binary)
 - Bubbles running (binary)
+- Jets running (binary)
 - Lock status (binary)
 - Error detection (binary)
 - Error code (text)
+- Display text
 
-## Hardware Compatibility
+## Supported Protocols & Models
 
-### Supported Models
+### 4-Wire UART (2021+ models)
+Standard UART protocol at 9600 baud. Most common on newer spas.
 
-**4-Wire (2021+ models):**
-- UART protocol, 9600 baud
-- Most common on newer spas
-- Default in this firmware
+| Model | Jets | Air | Notes |
+|-------|------|-----|-------|
+| 54123 | No | No | Basic model |
+| 54138 | Yes | Yes | Full featured |
+| 54144 | Yes | No | Jets only |
+| 54154 | No | No | Basic model (default) |
+| 54173 | Yes | Yes | Full featured |
 
-**6-Wire (Pre-2021 models):**
-- SPI-like protocol
-- Partially supported (work in progress)
+### 6-Wire SPI-like (Pre-2021 models)
+Uses CLK, DATA, and CS pins for communication. Two protocol variants:
 
-### Required Hardware
+**TYPE1 Models:**
+| Model | Jets | Air | Notes |
+|-------|------|-----|-------|
+| PRE2021 | No | Yes | Standard pre-2021 |
+| P05504 | No | Yes | Variant with different button codes |
 
-You need the **Visualapproach PCB** which includes:
+**TYPE2 Models:**
+| Model | Jets | Air | Notes |
+|-------|------|-----|-------|
+| 54149E | No | Yes | Different bit ordering |
+
+## Hardware Requirements
+
+### Required Components
+You need the **VisualApproach PCB** which includes:
 - ESP8266 (NodeMCU or compatible)
-- TXS0108E level shifter
+- TXS0108E bidirectional level shifter (8-channel)
 - Proper connectors for spa cable
-- Optional resistors (some models)
+- Optional: 510-560Ω resistors on signal lines
 
-**Get the PCB:**
-- [EasyEDA Project](https://oshwlab.com/visualapproach/bestway-wireless-controller-2_copy)
+### Where to Get Hardware
+- [EasyEDA/OSHWLab Project](https://oshwlab.com/visualapproach/bestway-wireless-controller-2_copy)
 - Order PCB_V2B design
-- See [Visualapproach build instructions](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA/blob/master/bwc-manual.pdf)
-
-## Installation
-
-### 1. Backup Current Firmware (Optional)
-
-If you want to keep Visualapproach firmware as backup:
-
-```bash
-esptool.py --port /dev/ttyUSB0 read_flash 0x00000 0x400000 visualapproach_backup.bin
-```
-
-### 2. Clone This Repository
-
-```bash
-git clone https://github.com/yourusername/bestway-esphome.git
-cd bestway-esphome
-```
-
-### 3. Configure Secrets
-
-```bash
-cp secrets.yaml.example secrets.yaml
-nano secrets.yaml
-```
-
-Fill in your WiFi credentials.
-
-### 4. Edit Configuration
-
-Edit `bestway-spa.yaml` if needed:
-
-```yaml
-substitutions:
-  friendly_name: "Hot Tub"  # Change to your preference
-
-# For pre-2021 models with 6-wire connection:
-climate:
-  - platform: bestway_spa
-    protocol_type: 6WIRE  # Change from 4WIRE
-```
-
-### 5. Compile and Flash
-
-**First time (USB cable required):**
-
-```bash
-esphome run bestway-spa.yaml
-```
-
-Select your serial port when prompted.
-
-**Subsequent updates (OTA):**
-
-```bash
-esphome run bestway-spa.yaml --device bestway-spa.local
-```
-
-Or use Home Assistant:
-- ESPHome Dashboard → Click device → Install → Wirelessly
-
-### 6. Add to Home Assistant
-
-Device auto-discovers via ESPHome API:
-1. Go to Settings → Devices & Services
-2. Click "Configure" on discovered ESPHome device
-3. Enter API key (shown in logs on first boot)
+- See [VisualApproach build instructions (PDF)](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA/blob/master/bwc-manual.pdf)
+- [VisualApproach GitHub Repository](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA)
 
 ## Pin Configuration
 
-### NodeMCU / ESP8266
-
+### 4-Wire Models (UART)
 ```
 GPIO1 (TX)  → Level Shifter → Spa TX
 GPIO3 (RX)  → Level Shifter → Spa RX
 GPIO2       → Built-in LED (status)
 ```
 
-**IMPORTANT:** Logging on serial is disabled since UART is used for spa communication. Use WiFi logging instead:
-
-```bash
-esphome logs bestway-spa.yaml
+### 6-Wire Models (SPI-like)
+```
+GPIO14 (D5) → Level Shifter → CLK (Clock)
+GPIO12 (D6) → Level Shifter → DATA (Bidirectional)
+GPIO13 (D7) → Level Shifter → CS (Chip Select)
+GPIO15 (D8) → Level Shifter → AUDIO (Optional buzzer)
+GPIO2       → Built-in LED (status)
 ```
 
-### Wiring
+**IMPORTANT:** Never connect ESP directly to spa - you will damage it! Always use level shifters.
 
-The Visualapproach PCB handles all level shifting (5V spa ↔ 3.3V ESP).
+## Installation
 
-**Never connect ESP directly to spa - you will damage it!**
+### 1. Clone This Repository
 
-## Usage
+```bash
+git clone https://github.com/tsquared96/ESPHome-Bestway-LazySpa.git
+cd ESPHome-Bestway-LazySpa
+```
+
+### 2. Configure Secrets
+
+```bash
+cp secrets.yaml.example secrets.yaml
+nano secrets.yaml
+```
+
+Fill in your WiFi credentials and encryption keys.
+
+### 3. Edit Configuration
+
+Edit `bestway-spa.yaml` to match your spa model:
+
+**For 4-wire (2021+) models:**
+```yaml
+climate:
+  - platform: bestway_spa
+    protocol_type: 4WIRE
+    model: "54154"  # Change to match your model
+```
+
+**For 6-wire TYPE1 (pre-2021) models:**
+```yaml
+climate:
+  - platform: bestway_spa
+    protocol_type: 6WIRE
+    model: PRE2021
+    clk_pin: GPIO14
+    data_pin: GPIO12
+    cs_pin: GPIO13
+    audio_pin: GPIO15
+```
+
+**For 6-wire TYPE2 (54149E) models:**
+```yaml
+climate:
+  - platform: bestway_spa
+    protocol_type: 6WIRE_T2
+    model: 54149E
+    clk_pin: GPIO14
+    data_pin: GPIO12
+    cs_pin: GPIO13
+```
+
+### 4. Compile and Flash
+
+**First time (USB cable required):**
+```bash
+esphome run bestway-spa.yaml
+```
+
+**Subsequent updates (OTA):**
+```bash
+esphome run bestway-spa.yaml --device bestway-spa.local
+```
+
+### 5. Add to Home Assistant
+
+Device auto-discovers via ESPHome API:
+1. Go to Settings → Devices & Services
+2. Click "Configure" on discovered ESPHome device
+3. Enter encryption key (from your secrets.yaml)
+
+## Configuration Reference
+
+### Protocol Types
+| Value | Description |
+|-------|-------------|
+| `4WIRE` | Standard UART (2021+ models) |
+| `6WIRE` | SPI-like TYPE1 (pre-2021) |
+| `6WIRE_T1` | Same as 6WIRE |
+| `6WIRE_T2` | SPI-like TYPE2 (54149E) |
+
+### Model Options
+| Value | Protocol | Jets | Air |
+|-------|----------|------|-----|
+| `PRE2021` | 6WIRE_T1 | No | Yes |
+| `P05504` | 6WIRE_T1 | No | Yes |
+| `54149E` | 6WIRE_T2 | No | Yes |
+| `54123` | 4WIRE | No | No |
+| `54138` | 4WIRE | Yes | Yes |
+| `54144` | 4WIRE | Yes | No |
+| `54154` | 4WIRE | No | No |
+| `54173` | 4WIRE | Yes | Yes |
+
+### Available Sensors
+
+**Temperature Sensors:**
+- `current_temperature` - Water temperature
+- `target_temperature` - Set point
+
+**Binary Sensors:**
+- `power` - Power state
+- `heating` - Heater active
+- `filter` - Filter pump running
+- `bubbles` - Air bubbles active
+- `jets` - Hydrojets active (if supported)
+- `locked` - Child lock engaged
+- `error` - Error detected
+
+**Text Sensors:**
+- `error_text` - Error code (E01, E02, etc.)
+- `display_text` - Current display content
+
+### Available Switches
+
+- `bestway_spa_power` - Power control
+- `bestway_spa_heater` - Heater control
+- `bestway_spa_filter` - Filter pump control
+- `bestway_spa_bubbles` - Bubbles control
+- `bestway_spa_jets` - Jets control (model-dependent)
+- `bestway_spa_lock` - Child lock control
+
+## Home Assistant Examples
 
 ### Dashboard Card
 
@@ -168,9 +241,8 @@ type: thermostat
 entity: climate.hot_tub
 ```
 
-### Automation Examples
+### Automation: Heat Before Evening
 
-**Heat before evening:**
 ```yaml
 automation:
   - alias: "Heat Spa Evening"
@@ -182,7 +254,7 @@ automation:
         target:
           entity_id: climate.hot_tub
         data:
-          temperature: 102
+          temperature: 39
       - service: climate.set_hvac_mode
         target:
           entity_id: climate.hot_tub
@@ -190,22 +262,8 @@ automation:
           hvac_mode: heat
 ```
 
-**Energy saving overnight:**
-```yaml
-automation:
-  - alias: "Spa Economy"
-    trigger:
-      - platform: time
-        at: "23:00:00"
-    action:
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.hot_tub
-        data:
-          temperature: 92
-```
+### Automation: Filter Cycle
 
-**Filter cycle:**
 ```yaml
 automation:
   - alias: "Filter Cycle"
@@ -224,12 +282,29 @@ automation:
           entity_id: switch.hot_tub_filter_pump
 ```
 
+### Automation: Bubbles Party Mode
+
+```yaml
+automation:
+  - alias: "Spa Party Mode"
+    trigger:
+      - platform: state
+        entity_id: input_boolean.spa_party_mode
+        to: "on"
+    action:
+      - service: switch.turn_on
+        target:
+          entity_id:
+            - switch.hot_tub_bubbles
+            - switch.hot_tub_jets
+```
+
 ## Troubleshooting
 
 ### Climate shows "unavailable"
 
-**Check serial connection:**
-- Verify UART pins are correct
+**Check connections:**
+- Verify UART/SPI pins are correct
 - Ensure level shifter is working
 - Check spa cable is connected
 
@@ -240,106 +315,71 @@ esphome logs bestway-spa.yaml
 
 Look for:
 - `Setting up Bestway Spa...`
-- `Bestway Spa initialized`
+- `Bestway Spa initialized (Protocol: ...)`
 - Packet receive messages
 
 ### No temperature updates
 
-**Add temperature smoothing:**
-
-The spa temperature sensor can be noisy. The example config includes smoothing:
-
-```yaml
-current_temperature:
-  filters:
-    - sliding_window_moving_average:
-        window_size: 3
-        send_every: 1
-```
+Verify your model selection is correct. Different models have different packet formats.
 
 ### Commands don't work
 
-**Increase command delay:**
+**For 6-wire models:**
+- Check CLK, DATA, CS pin assignments
+- Verify level shifter is bidirectional (TXS0108E, not TXB0108)
+- Some boards need 510-560Ω resistors on signal lines
 
-Some spas need more time between button presses:
-
-```cpp
-// In bestway_spa.cpp, adjust:
-PendingCommand cmd = {button, millis() + (i * 300), false};  // Increase from 200
-```
-
-### Won't compile
-
-**Check component path:**
-```yaml
-external_components:
-  - source:
-      type: local
-      path: components
-    components: [ bestway_spa ]
-```
-
-Path must be relative to your .yaml file.
+**For 4-wire models:**
+- Check TX/RX are not swapped
+- Verify baud rate is 9600
 
 ### Spa shows random errors
 
 **Level shifter issues:**
-
-Some boards need resistors between level shifter and spa:
-- 510-560Ω on CLK, DATA, CS lines (6-wire only)
-- See Visualapproach build instructions
+- Use TXS0108E (bidirectional) not TXB0108
+- Add resistors on signal lines if needed
+- Check all solder joints
 
 ## Protocol Details
 
 ### 4-Wire UART Protocol
 
-**Settings:**
-- Baud rate: 9600
-- Data bits: 8
-- Parity: None
-- Stop bits: 1
+**Settings:** 9600 baud, 8N1
 
-**Packet Types:**
+**Packet Format (7 bytes):**
+```
+[0xFF] [CMD] [TEMP] [ERR] [RSV] [CHK] [0xFF]
+```
 
-1. **Query (CIO → DSP):**
-   ```
-   0x1B 0x1B  // "No button pressed"
-   ```
+**Command Byte Bits:**
+- Bits vary by model (54123 vs 54138 etc.)
+- Controls heater stages, pump, bubbles, jets
 
-2. **Button Code (DSP → CIO):**
-   ```
-   0x10 0x12  // Heater button
-   0x10 0x13  // Filter button
-   0x10 0x14  // Bubbles button
-   0x10 0x15  // Temp up
-   0x10 0x16  // Temp down
-   0x10 0x17  // Lock
-   0x10 0x18  // Unit toggle
-   ```
+### 6-Wire SPI-like Protocol
 
-3. **Display Data (CIO → DSP):**
-   - Variable length packets
-   - Contains LED segment data
-   - Encodes temperature, LED states
+**TYPE1 (PRE2021, P05504):**
+- 11-byte payload
+- MSB-first transmission
+- Commands: 0x01 (mode), 0x40 (write), 0x42 (read)
 
-**Button Codes:**
-| Code | Function |
-|------|----------|
-| 0x1012 | Heater toggle |
-| 0x1013 | Filter toggle |
-| 0x1014 | Bubbles toggle |
-| 0x1015 | Temperature up |
-| 0x1016 | Temperature down |
-| 0x1017 | Child lock toggle |
-| 0x1018 | Unit (F/C) toggle |
+**TYPE2 (54149E):**
+- 5-byte payload
+- LSB-first transmission
+- Commands: 0x40, 0xC0, 0x88
 
-### Man-in-the-Middle Operation
+### Button Codes (6-Wire TYPE1)
 
-This firmware acts as a transparent proxy:
-1. Forwards all packets between CIO and DSP
-2. Monitors packets to extract state
-3. Injects button presses when HA commands received
-4. Updates HA with current state
+| Button | PRE2021 | P05504 |
+|--------|---------|--------|
+| No Button | 0x1B1B | 0x1B1B |
+| Lock | 0x0200 | 0x0210 |
+| Timer | 0x0100 | 0x0110 |
+| Bubbles | 0x0300 | 0x0310 |
+| Unit | 0x1012 | 0x1022 |
+| Heat | 0x1212 | 0x1222 |
+| Pump | 0x1112 | 0x1122 |
+| Down | 0x1312 | 0x1322 |
+| Up | 0x0809 | 0x081A |
 
 ## Development
 
@@ -348,7 +388,7 @@ This firmware acts as a transparent proxy:
 ```
 components/bestway_spa/
 ├── __init__.py         # ESPHome Python config
-├── bestway_spa.h       # C++ header
+├── bestway_spa.h       # C++ header with enums, structs
 └── bestway_spa.cpp     # C++ implementation
 ```
 
@@ -358,46 +398,22 @@ components/bestway_spa/
 esphome compile bestway-spa.yaml
 ```
 
-### Adding Features
+### Debugging
 
-To add new controls:
-
-1. Add switch in header:
-```cpp
-void set_my_feature(bool state);
-```
-
-2. Implement in cpp:
-```cpp
-void BestwaySpa::set_my_feature(bool state) {
-  PendingCommand cmd = {BTN_MY_FEATURE, millis(), false};
-  command_queue_.push_back(cmd);
-}
-```
-
-3. Add to Python config:
-```python
-BestwaySpaMyFeatureSwitch = bestway_spa_ns.class_(...)
-```
-
-4. Create switch in YAML:
-```yaml
-switch:
-  - platform: bestway_spa_my_feature
-    name: "My Feature"
-    bestway_spa_id: hot_tub
-```
-
-### Testing
-
-Use WiFi logging to monitor operation:
+Use WiFi logging:
 ```bash
 esphome logs bestway-spa.yaml --device bestway-spa.local
 ```
 
-## Comparison vs Visualapproach
+Set log level in YAML:
+```yaml
+logger:
+  level: VERBOSE  # Shows all packet data
+```
 
-| Feature | Visualapproach | This ESPHome |
+## Comparison: ESPHome vs VisualApproach
+
+| Feature | VisualApproach | This ESPHome |
 |---------|----------------|--------------|
 | MQTT | Required | Not needed |
 | Web UI | Built-in | Via HA |
@@ -406,41 +422,46 @@ esphome logs bestway-spa.yaml --device bestway-spa.local
 | OTA Updates | Custom | ESPHome |
 | Logs | Serial only | WiFi logs |
 | Automations | Limited | Full HA |
-| Scheduling | Built-in | HA automations |
+| 6-Wire Support | Full | Full |
+| Models Supported | All | All |
 
 ## Credits
 
-- **Visualapproach** - Original firmware and hardware design
+- **VisualApproach** - Original firmware, hardware design, and protocol documentation
 - **ESPHome** - Framework and tools
-- **Community** - Protocol reverse engineering
+- **Community** - Protocol reverse engineering and testing
 
 ## License
 
-MIT License
+MIT License - See LICENSE file
 
 ## Support
 
 - **Issues:** GitHub Issues
-- **Discussions:** GitHub Discussions
-- **HA Community:** Home Assistant Forums
-- **ESPHome:** Discord #custom-components
-
-## Future Plans
-
-- [ ] Complete 6-wire protocol implementation
-- [ ] Temperature calibration
-- [ ] More detailed error reporting
-- [ ] Power consumption estimation
-- [ ] Preset modes (Eco, Comfort, etc.)
-- [ ] Integration with solar systems
+- **Original Hardware:** [VisualApproach GitHub](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA)
 
 ## Changelog
+
+### v2.0.0 (2026-01-01)
+- **Complete 6-wire protocol implementation**
+  - TYPE1 support (PRE2021, P05504 models)
+  - TYPE2 support (54149E model)
+  - Full SPI-like bit-banging
+- **All models supported**
+  - 4-wire: 54123, 54138, 54144, 54154, 54173
+  - 6-wire: PRE2021, P05504, 54149E
+- **New features**
+  - Power switch
+  - Jets switch (model-dependent)
+  - Display text sensor
+  - Model-specific button codes
+  - Dual-stage heater control
+- **Improved**
+  - Button queue system for 6-wire
+  - State tracking
+  - Error handling
 
 ### v1.0.0 (2026-01-01)
 - Initial release
 - 4-wire UART protocol support
-- Full climate entity
-- All basic controls (heater, filter, bubbles, lock)
-- Temperature sensors
-- Error detection
-- Native HA integration
+- Basic climate entity and controls

--- a/bestway-spa.yaml
+++ b/bestway-spa.yaml
@@ -1,7 +1,10 @@
 # Bestway Lay-Z-Spa ESPHome Configuration
-# Direct serial communication - replaces Visualapproach firmware entirely
+# Native ESPHome component - direct serial/SPI protocol communication
 #
-# Uses existing Visualapproach hardware (PCB with level shifters)
+# Supports both 4-wire (2021+) and 6-wire (pre-2021) Bestway spa models
+# Based on VisualApproach hardware design and protocol documentation
+#
+# For hardware build instructions, see: https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA
 
 substitutions:
   device_name: bestway-spa
@@ -13,28 +16,28 @@ esphome:
   comment: "Bestway Lay-Z-Spa Controller"
 
 esp8266:
-  board: nodemcuv2  # Match your Visualapproach hardware
+  board: nodemcuv2  # NodeMCU v2/v3 ESP8266
 
-# Enable logging
+# Enable logging (disable serial logging since UART is used for spa)
 logger:
   level: DEBUG
-  baud_rate: 0  # Disable serial logging since UART is used for spa
+  baud_rate: 0
 
 # Enable Home Assistant API
 api:
   encryption:
     key: !secret api_encryption_key
 
-# Enable OTA
+# Enable OTA updates
 ota:
   - platform: esphome
     password: !secret ota_password
 
-# WiFi
+# WiFi configuration
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-  
+
   ap:
     ssid: "${friendly_name} Fallback"
     password: !secret fallback_password
@@ -43,7 +46,9 @@ wifi:
 web_server:
   port: 80
 
-# UART configuration for spa communication
+# =============================================================================
+# UART Configuration (used for both 4-wire UART and 6-wire CS/timing)
+# =============================================================================
 uart:
   id: spa_uart
   tx_pin: GPIO1   # D10/TX on NodeMCU
@@ -53,21 +58,72 @@ uart:
   parity: NONE
   stop_bits: 1
 
-# Custom component
+# =============================================================================
+# Custom Component
+# =============================================================================
 external_components:
   - source:
       type: local
       path: components
     components: [ bestway_spa ]
 
-# Main climate control with full sensors
+# =============================================================================
+# CLIMATE CONFIGURATION
+# =============================================================================
+#
+# Protocol options:
+#   4WIRE      - 2021+ models using UART (most common)
+#   6WIRE      - Pre-2021 models using SPI-like protocol (TYPE1)
+#   6WIRE_T1   - Same as 6WIRE (TYPE1)
+#   6WIRE_T2   - 6-wire TYPE2 (54149E model)
+#
+# Model options (affects button codes and features):
+#   PRE2021    - Pre-2021 6-wire model (TYPE1)
+#   P05504     - 6-wire TYPE1 variant
+#   54149E     - 6-wire TYPE2 model
+#   54123      - 4-wire, no jets, no air
+#   54138      - 4-wire with jets and air
+#   54144      - 4-wire with jets
+#   54154      - 4-wire basic (default)
+#   54173      - 4-wire with jets and air
+#
+# =============================================================================
+
 climate:
   - platform: bestway_spa
     id: hot_tub
     name: "${friendly_name}"
     uart_id: spa_uart
-    protocol_type: 4WIRE  # Use "6WIRE" for pre-2021 models
-    
+
+    # =========================================================================
+    # PROTOCOL CONFIGURATION - Choose ONE of these configurations:
+    # =========================================================================
+
+    # --- Option A: 4-Wire UART (2021+ models) ---
+    protocol_type: 4WIRE
+    model: "54154"  # Change to match your model number
+
+    # --- Option B: 6-Wire TYPE1 (Pre-2021 models) ---
+    # Uncomment and configure pins for 6-wire:
+    # protocol_type: 6WIRE
+    # model: PRE2021
+    # clk_pin: GPIO14   # D5 - Clock
+    # data_pin: GPIO12  # D6 - Data (bidirectional)
+    # cs_pin: GPIO13    # D7 - Chip Select
+    # audio_pin: GPIO15 # D8 - Audio/Buzzer (optional)
+
+    # --- Option C: 6-Wire TYPE2 (54149E model) ---
+    # protocol_type: 6WIRE_T2
+    # model: 54149E
+    # clk_pin: GPIO14
+    # data_pin: GPIO12
+    # cs_pin: GPIO13
+    # audio_pin: GPIO15
+
+    # =========================================================================
+    # SENSORS
+    # =========================================================================
+
     # Temperature sensors
     current_temperature:
       name: "${friendly_name} Current Temperature"
@@ -75,67 +131,93 @@ climate:
         - sliding_window_moving_average:
             window_size: 3
             send_every: 1
-    
+
     target_temperature:
       name: "${friendly_name} Target Temperature"
-    
-    # Binary sensors
+
+    # Binary sensors for state monitoring
     heating:
       name: "${friendly_name} Heating"
       device_class: heat
-    
+
     filter:
       name: "${friendly_name} Filter Running"
       device_class: running
-    
+
     bubbles:
-      name: "${friendly_name} Bubbles Running"
+      name: "${friendly_name} Bubbles"
       device_class: running
-    
+
+    jets:
+      name: "${friendly_name} Jets"
+      device_class: running
+
+    power:
+      name: "${friendly_name} Power"
+      device_class: power
+
     locked:
       name: "${friendly_name} Child Lock"
       device_class: lock
-    
+
     error:
       name: "${friendly_name} Error"
       device_class: problem
-    
-    # Error code text
+
+    # Text sensors
     error_text:
       name: "${friendly_name} Error Code"
 
-# Control switches
+    display_text:
+      name: "${friendly_name} Display"
+
+# =============================================================================
+# CONTROL SWITCHES
+# =============================================================================
+
 switch:
+  - platform: bestway_spa_power
+    name: "${friendly_name} Power"
+    icon: mdi:power
+    bestway_spa_id: hot_tub
+
   - platform: bestway_spa_heater
     name: "${friendly_name} Heater"
     icon: mdi:radiator
     bestway_spa_id: hot_tub
-  
+
   - platform: bestway_spa_filter
     name: "${friendly_name} Filter Pump"
     icon: mdi:air-filter
     bestway_spa_id: hot_tub
-  
+
   - platform: bestway_spa_bubbles
     name: "${friendly_name} Air Bubbles"
     icon: mdi:chart-bubble
     bestway_spa_id: hot_tub
-  
+
+  - platform: bestway_spa_jets
+    name: "${friendly_name} Jets"
+    icon: mdi:waves
+    bestway_spa_id: hot_tub
+
   - platform: bestway_spa_lock
     name: "${friendly_name} Child Lock"
     icon: mdi:lock
     bestway_spa_id: hot_tub
 
-# System sensors
+# =============================================================================
+# SYSTEM SENSORS
+# =============================================================================
+
 sensor:
   - platform: wifi_signal
     name: "${friendly_name} WiFi Signal"
     update_interval: 60s
-  
+
   - platform: uptime
     name: "${friendly_name} Uptime"
 
-# WiFi info
 text_sensor:
   - platform: wifi_info
     ip_address:
@@ -143,7 +225,10 @@ text_sensor:
     ssid:
       name: "${friendly_name} SSID"
 
-# Status LED (built-in)
+# =============================================================================
+# STATUS LED
+# =============================================================================
+
 status_led:
   pin:
     number: GPIO2

--- a/components/bestway_spa/__init__.py
+++ b/components/bestway_spa/__init__.py
@@ -1,12 +1,12 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import pins
 from esphome.components import climate, uart, sensor, binary_sensor, text_sensor, switch
 from esphome.const import (
     CONF_ID,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
-    UNIT_FAHRENHEIT,
 )
 
 DEPENDENCIES = ["uart"]
@@ -19,31 +19,93 @@ BestwaySpa = bestway_spa_ns.class_("BestwaySpa", climate.Climate, uart.UARTDevic
 ProtocolType = bestway_spa_ns.enum("ProtocolType")
 PROTOCOL_TYPES = {
     "4WIRE": ProtocolType.PROTOCOL_4WIRE,
-    "6WIRE": ProtocolType.PROTOCOL_6WIRE,
+    "6WIRE_T1": ProtocolType.PROTOCOL_6WIRE_T1,
+    "6WIRE_T2": ProtocolType.PROTOCOL_6WIRE_T2,
+    # Aliases for convenience
+    "6WIRE": ProtocolType.PROTOCOL_6WIRE_T1,
+    "6WIRE_TYPE1": ProtocolType.PROTOCOL_6WIRE_T1,
+    "6WIRE_TYPE2": ProtocolType.PROTOCOL_6WIRE_T2,
+}
+
+# Spa models
+SpaModel = bestway_spa_ns.enum("SpaModel")
+SPA_MODELS = {
+    "PRE2021": SpaModel.MODEL_PRE2021,
+    "54149E": SpaModel.MODEL_54149E,
+    "54123": SpaModel.MODEL_54123,
+    "54138": SpaModel.MODEL_54138,
+    "54144": SpaModel.MODEL_54144,
+    "54154": SpaModel.MODEL_54154,
+    "54173": SpaModel.MODEL_54173,
+    "P05504": SpaModel.MODEL_P05504,
+    # Common aliases
+    "MODEL_PRE2021": SpaModel.MODEL_PRE2021,
+    "MODEL_54149E": SpaModel.MODEL_54149E,
+    "NO54123": SpaModel.MODEL_54123,
+    "NO54138": SpaModel.MODEL_54138,
+    "NO54144": SpaModel.MODEL_54144,
+    "NO54154": SpaModel.MODEL_54154,
+    "NO54173": SpaModel.MODEL_54173,
 }
 
 # Switch classes
 BestwaySpaHeaterSwitch = bestway_spa_ns.class_("BestwaySpaHeaterSwitch", switch.Switch, cg.Component)
 BestwaySpaFilterSwitch = bestway_spa_ns.class_("BestwaySpaFilterSwitch", switch.Switch, cg.Component)
 BestwaySpaBubblesSwitch = bestway_spa_ns.class_("BestwaySpaBubblesSwitch", switch.Switch, cg.Component)
+BestwaySpaJetsSwitch = bestway_spa_ns.class_("BestwaySpaJetsSwitch", switch.Switch, cg.Component)
 BestwaySpaLockSwitch = bestway_spa_ns.class_("BestwaySpaLockSwitch", switch.Switch, cg.Component)
+BestwaySpaPowerSwitch = bestway_spa_ns.class_("BestwaySpaPowerSwitch", switch.Switch, cg.Component)
 
+# Configuration keys
 CONF_BESTWAY_SPA_ID = "bestway_spa_id"
 CONF_PROTOCOL_TYPE = "protocol_type"
+CONF_MODEL = "model"
+CONF_CLK_PIN = "clk_pin"
+CONF_DATA_PIN = "data_pin"
+CONF_CS_PIN = "cs_pin"
+CONF_AUDIO_PIN = "audio_pin"
 CONF_CURRENT_TEMPERATURE = "current_temperature"
 CONF_TARGET_TEMPERATURE = "target_temperature"
 CONF_HEATING = "heating"
 CONF_FILTER = "filter"
 CONF_BUBBLES = "bubbles"
+CONF_JETS = "jets"
 CONF_LOCKED = "locked"
+CONF_POWER = "power"
 CONF_ERROR = "error"
 CONF_ERROR_TEXT = "error_text"
+CONF_DISPLAY_TEXT = "display_text"
+
+
+def validate_6wire_pins(config):
+    """Validate that 6-wire protocols have required pins configured."""
+    protocol = config.get(CONF_PROTOCOL_TYPE, "4WIRE")
+    if protocol in ["6WIRE", "6WIRE_T1", "6WIRE_T2", "6WIRE_TYPE1", "6WIRE_TYPE2"]:
+        if CONF_CLK_PIN not in config:
+            raise cv.Invalid("clk_pin is required for 6-wire protocols")
+        if CONF_DATA_PIN not in config:
+            raise cv.Invalid("data_pin is required for 6-wire protocols")
+        if CONF_CS_PIN not in config:
+            raise cv.Invalid("cs_pin is required for 6-wire protocols")
+    return config
+
 
 CONFIG_SCHEMA = cv.All(
     climate.CLIMATE_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(BestwaySpa),
+
+            # Protocol configuration
             cv.Optional(CONF_PROTOCOL_TYPE, default="4WIRE"): cv.enum(PROTOCOL_TYPES, upper=True),
+            cv.Optional(CONF_MODEL, default="54154"): cv.enum(SPA_MODELS, upper=True),
+
+            # 6-wire pin configuration
+            cv.Optional(CONF_CLK_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_DATA_PIN): pins.internal_gpio_pin_schema,
+            cv.Optional(CONF_CS_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_AUDIO_PIN): pins.gpio_output_pin_schema,
+
+            # Temperature sensors
             cv.Optional(CONF_CURRENT_TEMPERATURE): sensor.sensor_schema(
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
@@ -54,16 +116,24 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
                 accuracy_decimals=1,
             ),
+
+            # Binary sensors
             cv.Optional(CONF_HEATING): binary_sensor.binary_sensor_schema(),
             cv.Optional(CONF_FILTER): binary_sensor.binary_sensor_schema(),
             cv.Optional(CONF_BUBBLES): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_JETS): binary_sensor.binary_sensor_schema(),
             cv.Optional(CONF_LOCKED): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_POWER): binary_sensor.binary_sensor_schema(),
             cv.Optional(CONF_ERROR): binary_sensor.binary_sensor_schema(),
+
+            # Text sensors
             cv.Optional(CONF_ERROR_TEXT): text_sensor.text_sensor_schema(),
+            cv.Optional(CONF_DISPLAY_TEXT): text_sensor.text_sensor_schema(),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    validate_6wire_pins,
 )
 
 
@@ -72,47 +142,82 @@ async def to_code(config):
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await uart.register_uart_device(var, config)
-    
+
     # Set protocol type
     cg.add(var.set_protocol_type(config[CONF_PROTOCOL_TYPE]))
-    
-    # Register sensors
+
+    # Set model
+    cg.add(var.set_model(config[CONF_MODEL]))
+
+    # Configure 6-wire pins
+    if CONF_CLK_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_CLK_PIN])
+        cg.add(var.set_clk_pin(pin))
+
+    if CONF_DATA_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_DATA_PIN])
+        cg.add(var.set_data_pin(pin))
+
+    if CONF_CS_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_CS_PIN])
+        cg.add(var.set_cs_pin(pin))
+
+    if CONF_AUDIO_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_AUDIO_PIN])
+        cg.add(var.set_audio_pin(pin))
+
+    # Register temperature sensors
     if CONF_CURRENT_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_CURRENT_TEMPERATURE])
         cg.add(var.set_current_temperature_sensor(sens))
-    
+
     if CONF_TARGET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TARGET_TEMPERATURE])
         cg.add(var.set_target_temperature_sensor(sens))
-    
+
     # Register binary sensors
     if CONF_HEATING in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_HEATING])
         cg.add(var.set_heating_sensor(sens))
-    
+
     if CONF_FILTER in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_FILTER])
         cg.add(var.set_filter_sensor(sens))
-    
+
     if CONF_BUBBLES in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_BUBBLES])
         cg.add(var.set_bubbles_sensor(sens))
-    
+
+    if CONF_JETS in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_JETS])
+        cg.add(var.set_jets_sensor(sens))
+
     if CONF_LOCKED in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_LOCKED])
         cg.add(var.set_locked_sensor(sens))
-    
+
+    if CONF_POWER in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_POWER])
+        cg.add(var.set_power_sensor(sens))
+
     if CONF_ERROR in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_ERROR])
         cg.add(var.set_error_sensor(sens))
-    
-    # Register text sensor
+
+    # Register text sensors
     if CONF_ERROR_TEXT in config:
         sens = await text_sensor.new_text_sensor(config[CONF_ERROR_TEXT])
         cg.add(var.set_error_text_sensor(sens))
 
+    if CONF_DISPLAY_TEXT in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_DISPLAY_TEXT])
+        cg.add(var.set_display_text_sensor(sens))
 
-# Switch platforms
+
+# =============================================================================
+# SWITCH PLATFORMS
+# =============================================================================
+
 BESTWAY_SPA_SWITCH_SCHEMA = switch.switch_schema().extend({
     cv.GenerateID(CONF_BESTWAY_SPA_ID): cv.use_id(BestwaySpa),
 })
@@ -142,7 +247,19 @@ async def bubbles_switch_to_code(config):
     await register_bestway_switch(var, config)
 
 
+@cv.validate_registry("switch", "bestway_spa_jets")
+async def jets_switch_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID], BestwaySpaJetsSwitch())
+    await register_bestway_switch(var, config)
+
+
 @cv.validate_registry("switch", "bestway_spa_lock")
 async def lock_switch_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID], BestwaySpaLockSwitch())
+    await register_bestway_switch(var, config)
+
+
+@cv.validate_registry("switch", "bestway_spa_power")
+async def power_switch_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID], BestwaySpaPowerSwitch())
     await register_bestway_switch(var, config)

--- a/components/bestway_spa/bestway_spa.cpp
+++ b/components/bestway_spa/bestway_spa.cpp
@@ -7,75 +7,296 @@ namespace bestway_spa {
 
 static const char *const TAG = "bestway_spa";
 
-// Protocol timing constants (from Visualapproach)
+// =============================================================================
+// TIMING CONSTANTS - Based on VisualApproach firmware
+// =============================================================================
+
 static const uint32_t PACKET_TIMEOUT_MS = 100;
-static const uint32_t RESPONSE_TIMEOUT_MS = 50;
 static const uint32_t STATE_UPDATE_INTERVAL_MS = 500;
 static const uint32_t SENSOR_UPDATE_INTERVAL_MS = 2000;
+static const uint32_t DSP_REFRESH_INTERVAL_MS = 50;      // ~20Hz display refresh
+static const uint32_t BUTTON_POLL_INTERVAL_MS = 100;
+static const uint32_t BUTTON_DEBOUNCE_MS = 50;
+static const uint32_t CLOCK_PULSE_US = 50;               // Clock pulse width
+
+// 6-wire TYPE1 protocol constants
+static const uint8_t DSP_CMD1_MODE6_11_7 = 0x01;
+static const uint8_t DSP_CMD1_MODE6_11_7_P05504 = 0x05;
+static const uint8_t DSP_CMD2_DATAREAD = 0x42;
+static const uint8_t DSP_CMD2_DATAWRITE = 0x40;
+static const uint8_t DSP_DIM_BASE = 0x80;
+static const uint8_t DSP_DIM_ON = 0x08;
+
+// 6-wire TYPE2 protocol constants
+static const uint8_t TYPE2_CMD1 = 0x40;
+static const uint8_t TYPE2_CMD2 = 0xC0;
+static const uint8_t TYPE2_CMD3 = 0x88;
+
+// Payload byte indices for TYPE1 (11-byte payload)
+static const uint8_t T1_DGT1_IDX = 1;
+static const uint8_t T1_DGT2_IDX = 3;
+static const uint8_t T1_DGT3_IDX = 5;
+static const uint8_t T1_TIMER_IDX = 7;
+static const uint8_t T1_TIMER_BIT = 1;
+static const uint8_t T1_LOCK_IDX = 7;
+static const uint8_t T1_LOCK_BIT = 2;
+static const uint8_t T1_HEATGRN_IDX = 9;
+static const uint8_t T1_HEATGRN_BIT = 0;
+static const uint8_t T1_HEATRED_IDX = 9;
+static const uint8_t T1_HEATRED_BIT = 3;
+static const uint8_t T1_AIR_IDX = 9;
+static const uint8_t T1_AIR_BIT = 1;
+static const uint8_t T1_FILTER_IDX = 9;
+static const uint8_t T1_FILTER_BIT = 2;
+static const uint8_t T1_C_IDX = 7;
+static const uint8_t T1_C_BIT = 0;
+static const uint8_t T1_F_IDX = 9;
+static const uint8_t T1_F_BIT = 4;
+static const uint8_t T1_POWER_IDX = 9;
+static const uint8_t T1_POWER_BIT = 5;
+static const uint8_t T1_JETS_IDX = 9;
+static const uint8_t T1_JETS_BIT = 6;
+
+// Payload byte indices for TYPE2 (5-byte payload)
+static const uint8_t T2_DGT1_IDX = 0;
+static const uint8_t T2_DGT2_IDX = 1;
+static const uint8_t T2_DGT3_IDX = 2;
+static const uint8_t T2_TIMER_IDX = 3;
+static const uint8_t T2_TIMER_BIT = 0;
+static const uint8_t T2_LOCK_IDX = 3;
+static const uint8_t T2_LOCK_BIT = 1;
+static const uint8_t T2_HEATGRN_IDX = 3;
+static const uint8_t T2_HEATGRN_BIT = 2;
+static const uint8_t T2_HEATRED_IDX = 3;
+static const uint8_t T2_HEATRED_BIT = 3;
+static const uint8_t T2_AIR_IDX = 3;
+static const uint8_t T2_AIR_BIT = 4;
+static const uint8_t T2_FILTER_IDX = 3;
+static const uint8_t T2_FILTER_BIT = 5;
+static const uint8_t T2_C_IDX = 3;
+static const uint8_t T2_C_BIT = 6;
+static const uint8_t T2_F_IDX = 3;
+static const uint8_t T2_F_BIT = 7;
+static const uint8_t T2_POWER_IDX = 4;
+static const uint8_t T2_POWER_BIT = 0;
+static const uint8_t T2_JETS_IDX = 4;
+static const uint8_t T2_JETS_BIT = 1;
+
+// =============================================================================
+// SETUP
+// =============================================================================
 
 void BestwaySpa::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Bestway Spa...");
-  
+
+  // Set model configuration for 4-wire models
+  switch (model_) {
+    case MODEL_54123:
+      model_config_ = &CONFIG_54123;
+      break;
+    case MODEL_54138:
+      model_config_ = &CONFIG_54138;
+      break;
+    case MODEL_54144:
+      model_config_ = &CONFIG_54144;
+      break;
+    case MODEL_54154:
+      model_config_ = &CONFIG_54154;
+      break;
+    case MODEL_54173:
+      model_config_ = &CONFIG_54173;
+      break;
+    default:
+      model_config_ = &CONFIG_54154;
+      break;
+  }
+
+  // Initialize 6-wire pins
+  if (protocol_type_ == PROTOCOL_6WIRE_T1 || protocol_type_ == PROTOCOL_6WIRE_T2) {
+    if (clk_pin_ != nullptr) {
+      clk_pin_->setup();
+      clk_pin_->digital_write(false);  // Clock idle low
+    }
+    if (data_pin_ != nullptr) {
+      data_pin_->setup();
+      data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+      data_pin_->digital_write(true);  // Data idle high
+    }
+    if (cs_pin_ != nullptr) {
+      cs_pin_->setup();
+      cs_pin_->digital_write(true);    // CS idle high
+    }
+    if (audio_pin_ != nullptr) {
+      audio_pin_->setup();
+      audio_pin_->digital_write(false);
+    }
+
+    // Initialize default DSP payload
+    if (protocol_type_ == PROTOCOL_6WIRE_T1) {
+      dsp_payload_len_ = 11;
+      dsp_payload_[0] = (model_ == MODEL_P05504) ? DSP_CMD1_MODE6_11_7_P05504 : DSP_CMD1_MODE6_11_7;
+      dsp_payload_[1] = 0x00;  // Digit 1
+      dsp_payload_[2] = 0x00;
+      dsp_payload_[3] = 0x00;  // Digit 2
+      dsp_payload_[4] = 0x00;
+      dsp_payload_[5] = 0x00;  // Digit 3
+      dsp_payload_[6] = 0x00;
+      dsp_payload_[7] = 0x00;  // Status byte 1
+      dsp_payload_[8] = 0x00;
+      dsp_payload_[9] = 0x00;  // Status byte 2
+      dsp_payload_[10] = 0x00;
+    } else {
+      dsp_payload_len_ = 5;
+    }
+  }
+
   // Initialize climate state
-  this->mode = climate::CLIMATE_MODE_HEAT;
+  this->mode = climate::CLIMATE_MODE_OFF;
   this->action = climate::CLIMATE_ACTION_IDLE;
   this->current_temperature = state_.current_temp;
   this->target_temperature = state_.target_temp;
-  
-  ESP_LOGCONFIG(TAG, "Bestway Spa initialized (Protocol: %s)", 
-                protocol_type_ == PROTOCOL_4WIRE ? "4-wire" : "6-wire");
+
+  const char *proto_str;
+  switch (protocol_type_) {
+    case PROTOCOL_4WIRE:
+      proto_str = "4-wire UART";
+      break;
+    case PROTOCOL_6WIRE_T1:
+      proto_str = "6-wire TYPE1";
+      break;
+    case PROTOCOL_6WIRE_T2:
+      proto_str = "6-wire TYPE2";
+      break;
+    default:
+      proto_str = "unknown";
+  }
+
+  ESP_LOGCONFIG(TAG, "Bestway Spa initialized (Protocol: %s)", proto_str);
 }
+
+// =============================================================================
+// MAIN LOOP
+// =============================================================================
 
 void BestwaySpa::loop() {
   const uint32_t now = millis();
-  
-  // Handle protocol based on type
-  if (protocol_type_ == PROTOCOL_4WIRE) {
-    handle_4wire_protocol_();
-  } else {
-    handle_6wire_protocol_();
+
+  if (paused_) {
+    return;
   }
-  
+
+  // Handle protocol based on type
+  switch (protocol_type_) {
+    case PROTOCOL_4WIRE:
+      handle_4wire_protocol_();
+      break;
+    case PROTOCOL_6WIRE_T1:
+      handle_6wire_type1_protocol_();
+      break;
+    case PROTOCOL_6WIRE_T2:
+      handle_6wire_type2_protocol_();
+      break;
+  }
+
+  // Process button queue (for 6-wire)
+  if (protocol_type_ != PROTOCOL_4WIRE) {
+    process_button_queue_();
+  }
+
+  // Handle toggle requests
+  handle_toggles_();
+
   // Update climate state periodically
   if (now - last_state_update_ > STATE_UPDATE_INTERVAL_MS) {
     update_climate_state_();
     last_state_update_ = now;
   }
-  
+
   // Update sensors periodically
   if (now - last_sensor_update_ > SENSOR_UPDATE_INTERVAL_MS) {
     update_sensors_();
     last_sensor_update_ = now;
   }
-  
-  // Process command queue
-  if (!command_queue_.empty() && !waiting_for_response_) {
-    auto &cmd = command_queue_.front();
-    if (!cmd.processed && (now - cmd.time) >= 100) {  // Debounce
-      send_button_press_(cmd.button);
-      cmd.processed = true;
-      waiting_for_response_ = true;
-      command_queue_.erase(command_queue_.begin());
-    }
-  }
-  
-  // Reset waiting flag if timeout
-  if (waiting_for_response_ && (now - last_packet_time_) > RESPONSE_TIMEOUT_MS) {
-    waiting_for_response_ = false;
-  }
 }
+
+// =============================================================================
+// CONFIG DUMP
+// =============================================================================
 
 void BestwaySpa::dump_config() {
   ESP_LOGCONFIG(TAG, "Bestway Spa:");
-  ESP_LOGCONFIG(TAG, "  Protocol: %s", protocol_type_ == PROTOCOL_4WIRE ? "4-wire UART" : "6-wire SPI-like");
+
+  const char *proto_str;
+  switch (protocol_type_) {
+    case PROTOCOL_4WIRE:
+      proto_str = "4-wire UART";
+      break;
+    case PROTOCOL_6WIRE_T1:
+      proto_str = "6-wire TYPE1 (SPI-like)";
+      break;
+    case PROTOCOL_6WIRE_T2:
+      proto_str = "6-wire TYPE2 (SPI-like)";
+      break;
+    default:
+      proto_str = "unknown";
+  }
+  ESP_LOGCONFIG(TAG, "  Protocol: %s", proto_str);
+
+  const char *model_str;
+  switch (model_) {
+    case MODEL_PRE2021:
+      model_str = "PRE2021";
+      break;
+    case MODEL_54149E:
+      model_str = "54149E";
+      break;
+    case MODEL_54123:
+      model_str = "54123";
+      break;
+    case MODEL_54138:
+      model_str = "54138 (with jets and air)";
+      break;
+    case MODEL_54144:
+      model_str = "54144 (with jets)";
+      break;
+    case MODEL_54154:
+      model_str = "54154";
+      break;
+    case MODEL_54173:
+      model_str = "54173 (with jets and air)";
+      break;
+    case MODEL_P05504:
+      model_str = "P05504";
+      break;
+    default:
+      model_str = "unknown";
+  }
+  ESP_LOGCONFIG(TAG, "  Model: %s", model_str);
+  ESP_LOGCONFIG(TAG, "  Has Jets: %s", has_jets() ? "yes" : "no");
+  ESP_LOGCONFIG(TAG, "  Has Air: %s", has_air() ? "yes" : "no");
+
+  if (protocol_type_ != PROTOCOL_4WIRE) {
+    if (clk_pin_ != nullptr)
+      ESP_LOGCONFIG(TAG, "  CLK Pin: GPIO%d", clk_pin_->get_pin());
+    if (data_pin_ != nullptr)
+      ESP_LOGCONFIG(TAG, "  DATA Pin: GPIO%d", data_pin_->get_pin());
+    if (cs_pin_ != nullptr)
+      ESP_LOGCONFIG(TAG, "  CS Pin: GPIO%d", cs_pin_->get_pin());
+  }
+
   LOG_CLIMATE("", "Bestway Spa Climate", this);
 }
+
+// =============================================================================
+// CLIMATE TRAITS
+// =============================================================================
 
 climate::ClimateTraits BestwaySpa::traits() {
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(true);
   traits.set_supports_two_point_target_temperature(false);
-  
+
+  // Temperature range depends on unit
   if (state_.unit_celsius) {
     traits.set_visual_min_temperature(20.0f);
     traits.set_visual_max_temperature(40.0f);
@@ -83,54 +304,56 @@ climate::ClimateTraits BestwaySpa::traits() {
     traits.set_visual_min_temperature(68.0f);
     traits.set_visual_max_temperature(104.0f);
   }
-  
+
   traits.set_visual_temperature_step(1.0f);
   traits.set_supported_modes({
     climate::CLIMATE_MODE_OFF,
     climate::CLIMATE_MODE_HEAT,
     climate::CLIMATE_MODE_FAN_ONLY
   });
-  
+
   return traits;
 }
+
+// =============================================================================
+// CLIMATE CONTROL
+// =============================================================================
 
 void BestwaySpa::control(const climate::ClimateCall &call) {
   if (call.get_mode().has_value()) {
     climate::ClimateMode mode = *call.get_mode();
-    
+
     switch (mode) {
       case climate::CLIMATE_MODE_OFF:
         set_heater(false);
         set_filter(false);
         break;
-        
+
       case climate::CLIMATE_MODE_HEAT:
         set_heater(true);
+        set_filter(true);
         break;
-        
+
       case climate::CLIMATE_MODE_FAN_ONLY:
         set_heater(false);
         set_filter(true);
         break;
-        
+
       default:
         break;
     }
   }
-  
+
   if (call.get_target_temperature().has_value()) {
     float new_target = *call.get_target_temperature();
-    float delta = new_target - state_.target_temp;
-    
-    // Send button presses to adjust temperature
-    int8_t steps = (int8_t)roundf(delta);
-    if (steps != 0) {
-      adjust_target_temp(steps);
-    }
+    set_target_temp(new_target);
   }
 }
 
-// 4-Wire UART Protocol Handler
+// =============================================================================
+// 4-WIRE UART PROTOCOL HANDLER
+// =============================================================================
+
 void BestwaySpa::handle_4wire_protocol_() {
   // Read available bytes from UART
   while (available()) {
@@ -139,260 +362,830 @@ void BestwaySpa::handle_4wire_protocol_() {
     rx_buffer_.push_back(byte);
     last_packet_time_ = millis();
   }
-  
-  // Process complete packets
-  if (rx_buffer_.size() >= 2) {
-    const uint32_t now = millis();
-    
-    // Check if we have a query packet (0x1B 0x1B = no button pressed)
-    if (rx_buffer_.size() == 2 && 
-        rx_buffer_[0] == 0x1B && rx_buffer_[1] == 0x1B) {
-      // CIO is asking DSP which button is pressed
-      parse_cio_to_dsp_packet_(rx_buffer_);
-      rx_buffer_.clear();
-    }
-    // Button code packet (0x10 0xXX)
-    else if (rx_buffer_.size() == 2 && rx_buffer_[0] == 0x10) {
-      parse_cio_to_dsp_packet_(rx_buffer_);
-      rx_buffer_.clear();
-    }
-    // Display segment data (longer packets)
-    else if (rx_buffer_.size() > 2 && (now - last_packet_time_) > PACKET_TIMEOUT_MS) {
-      parse_cio_to_dsp_packet_(rx_buffer_);
-      rx_buffer_.clear();
+
+  // Process complete packets (7-byte fixed format)
+  if (rx_buffer_.size() >= 7) {
+    // Check for valid packet start/end markers
+    if (rx_buffer_[0] == 0xFF && rx_buffer_[6] == 0xFF) {
+      // Validate checksum
+      uint8_t calc_sum = rx_buffer_[1] + rx_buffer_[2] + rx_buffer_[3] + rx_buffer_[4];
+      if (calc_sum == rx_buffer_[5]) {
+        parse_4wire_packet_(rx_buffer_);
+        new_packet_available_ = true;
+      } else {
+        ESP_LOGW(TAG, "4-wire checksum mismatch: calc=%02X, recv=%02X", calc_sum, rx_buffer_[5]);
+      }
+      rx_buffer_.erase(rx_buffer_.begin(), rx_buffer_.begin() + 7);
+    } else {
+      // Invalid packet, skip first byte
+      rx_buffer_.erase(rx_buffer_.begin());
     }
   }
-  
-  // Clear buffer if timeout
+
+  // Clear buffer on timeout
   if (!rx_buffer_.empty() && (millis() - last_packet_time_) > PACKET_TIMEOUT_MS) {
-    ESP_LOGV(TAG, "Packet timeout, clearing buffer");
+    ESP_LOGV(TAG, "4-wire packet timeout, clearing %d bytes", rx_buffer_.size());
     rx_buffer_.clear();
   }
-}
 
-// 6-Wire Protocol Handler (placeholder for future implementation)
-void BestwaySpa::handle_6wire_protocol_() {
-  ESP_LOGW(TAG, "6-wire protocol not yet implemented");
-  // TODO: Implement 6-wire SPI-like protocol
-}
-
-// Parse packets from CIO to DSP
-void BestwaySpa::parse_cio_to_dsp_packet_(const std::vector<uint8_t> &packet) {
-  if (packet.size() < 2) return;
-  
-  // Query packet - CIO asking DSP for button state
-  if (packet[0] == 0x1B && packet[1] == 0x1B) {
-    ESP_LOGV(TAG, "CIO query: no button pressed");
-    
-    // If we have a pending command, respond with button code
-    // Otherwise forward the query
-    forward_packet_(packet);
-    return;
+  // Send response if we have pending commands
+  if (new_packet_available_) {
+    send_4wire_response_();
+    new_packet_available_ = false;
   }
-  
-  // Button acknowledgment packet
-  if (packet[0] == 0x10) {
-    uint8_t button_code = packet[1];
-    ESP_LOGD(TAG, "Button code: 0x%02X", button_code);
-    
-    // Update state based on button
-    switch (button_code) {
-      case 0x12:  // Heater
-        state_.heater = !state_.heater;
-        break;
-      case 0x13:  // Filter
-        state_.filter = !state_.filter;
-        break;
-      case 0x14:  // Bubbles
-        state_.bubbles = !state_.bubbles;
-        break;
-      case 0x15:  // Temp up
-        state_.target_temp += 1.0f;
-        if (!state_.unit_celsius && state_.target_temp > 104.0f) state_.target_temp = 104.0f;
-        if (state_.unit_celsius && state_.target_temp > 40.0f) state_.target_temp = 40.0f;
-        break;
-      case 0x16:  // Temp down
-        state_.target_temp -= 1.0f;
-        if (!state_.unit_celsius && state_.target_temp < 68.0f) state_.target_temp = 68.0f;
-        if (state_.unit_celsius && state_.target_temp < 20.0f) state_.target_temp = 20.0f;
-        break;
-      case 0x17:  // Lock
-        state_.locked = !state_.locked;
-        break;
-      case 0x18:  // Unit toggle
-        state_.unit_celsius = !state_.unit_celsius;
-        // Convert temperatures
-        if (state_.unit_celsius) {
-          state_.current_temp = fahrenheit_to_celsius_(state_.current_temp);
-          state_.target_temp = fahrenheit_to_celsius_(state_.target_temp);
-        } else {
-          state_.current_temp = celsius_to_fahrenheit_(state_.current_temp);
-          state_.target_temp = celsius_to_fahrenheit_(state_.target_temp);
-        }
-        break;
+}
+
+void BestwaySpa::parse_4wire_packet_(const std::vector<uint8_t> &packet) {
+  if (packet.size() < 7) return;
+
+  // Extract command byte and temperature
+  uint8_t command = packet[1];
+  uint8_t temp_raw = packet[2];
+  uint8_t error = packet[3];
+
+  // Parse temperature (raw value is actual temperature)
+  state_.current_temp = (float)temp_raw;
+
+  // Parse error code
+  state_.error_code = error;
+
+  // Parse state flags from command byte
+  state_.filter_pump = (command & model_config_->pump_bitmask) != 0;
+  state_.bubbles = (command & model_config_->bubbles_bitmask) != 0;
+  if (model_config_->has_jets) {
+    state_.jets = (command & model_config_->jets_bitmask) != 0;
+  }
+
+  // Parse heater state (dual stage)
+  bool heat1 = (command & model_config_->heat_bitmask1) != 0;
+  bool heat2 = (command & model_config_->heat_bitmask2) != 0;
+  state_.heater_red = heat1 || heat2;
+  state_.heater_green = state_.heater_enabled && !state_.heater_red;
+  state_.heater_enabled = state_.heater_red || state_.heater_green;
+
+  ESP_LOGV(TAG, "4-wire: cmd=%02X temp=%d err=%d pump=%d bubbles=%d heat=%d",
+           command, temp_raw, error, state_.filter_pump, state_.bubbles, state_.heater_red);
+}
+
+void BestwaySpa::send_4wire_response_() {
+  // Build response packet
+  uint8_t packet[7];
+  packet[0] = 0xFF;  // Start marker
+
+  // Command byte with requested states
+  uint8_t command = 0;
+
+  // Heater control with staged startup
+  if (state_.heater_enabled) {
+    uint32_t now = millis();
+    if (heater_stage_ == 0) {
+      // Start stage 1
+      heater_stage_ = 1;
+      stage_start_time_ = now;
+      command |= model_config_->heat_bitmask1;
+    } else if (heater_stage_ == 1) {
+      // Stage 1 active, check if time to advance
+      command |= model_config_->heat_bitmask1;
+      if ((now - stage_start_time_) > 10000) {  // 10 second delay
+        heater_stage_ = 2;
+      }
+    } else {
+      // Both stages active
+      command |= model_config_->heat_bitmask1;
+      command |= model_config_->heat_bitmask2;
     }
-    
-    forward_packet_(packet);
+  } else {
+    heater_stage_ = 0;
+  }
+
+  if (state_.filter_pump) {
+    command |= model_config_->pump_bitmask;
+  }
+  if (state_.bubbles) {
+    command |= model_config_->bubbles_bitmask;
+  }
+  if (model_config_->has_jets && state_.jets) {
+    command |= model_config_->jets_bitmask;
+  }
+
+  packet[1] = command;
+  packet[2] = (uint8_t)state_.target_temp;  // Target temperature
+  packet[3] = 0x00;  // Reserved
+  packet[4] = 0x00;  // Reserved
+  packet[5] = packet[1] + packet[2] + packet[3] + packet[4];  // Checksum
+  packet[6] = 0xFF;  // End marker
+
+  write_array(packet, 7);
+  flush();
+}
+
+// =============================================================================
+// 6-WIRE TYPE1 PROTOCOL HANDLER
+// =============================================================================
+
+void BestwaySpa::handle_6wire_type1_protocol_() {
+  uint32_t now = millis();
+
+  // Refresh DSP display at regular intervals
+  if (now - last_dsp_refresh_ >= DSP_REFRESH_INTERVAL_MS) {
+    send_dsp_payload_type1_();
+    last_dsp_refresh_ = now;
+  }
+
+  // Poll for button presses at regular intervals
+  if (now - last_button_poll_ >= BUTTON_POLL_INTERVAL_MS) {
+    receive_cio_payload_type1_();
+    update_states_from_payload_();
+    last_button_poll_ = now;
+  }
+}
+
+void BestwaySpa::send_dsp_payload_type1_() {
+  if (cs_pin_ == nullptr || clk_pin_ == nullptr || data_pin_ == nullptr) {
+    ESP_LOGW(TAG, "6-wire pins not configured");
     return;
   }
-  
-  // Display segment data - extract temperature and LED states
-  if (packet.size() > 4) {
-    ESP_LOGV(TAG, "Display segment data, %d bytes", packet.size());
-    
-    // Parse LED states from segment data
-    // This is a simplified version - actual parsing depends on packet structure
-    // Based on Visualapproach code, LED states are encoded in the segment data
-    
-    // For now, just forward the packet
-    forward_packet_(packet);
+
+  // Set data pin to output mode
+  data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+
+  // Start transmission - CS low
+  cs_pin_->digital_write(false);
+  delayMicroseconds(10);
+
+  // Send 11-byte payload
+  for (size_t i = 0; i < 11; i++) {
+    send_bits_to_dsp_(dsp_payload_[i], 8);
+  }
+
+  // End transmission - CS high
+  cs_pin_->digital_write(true);
+}
+
+void BestwaySpa::receive_cio_payload_type1_() {
+  if (cs_pin_ == nullptr || clk_pin_ == nullptr || data_pin_ == nullptr) {
+    return;
+  }
+
+  // Send command to request button state
+  data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+
+  cs_pin_->digital_write(false);
+  delayMicroseconds(10);
+
+  // Send data read command
+  uint8_t cmd1 = (model_ == MODEL_P05504) ? DSP_CMD1_MODE6_11_7_P05504 : DSP_CMD1_MODE6_11_7;
+  send_bits_to_dsp_(cmd1, 8);
+  send_bits_to_dsp_(DSP_CMD2_DATAREAD, 8);
+
+  // Switch to input mode
+  data_pin_->pin_mode(gpio::FLAG_INPUT);
+  delayMicroseconds(10);
+
+  // Read 16-bit button code
+  uint16_t button_code = receive_bits_from_dsp_(16);
+
+  // End transmission
+  cs_pin_->digital_write(true);
+
+  // Store button code if valid
+  if (button_code != 0xFFFF) {
+    current_button_code_ = button_code;
+    ESP_LOGV(TAG, "6-wire TYPE1 button code: 0x%04X", button_code);
   }
 }
 
-// Parse packets from DSP to CIO (button presses from physical panel)
-void BestwaySpa::parse_dsp_to_cio_packet_(const std::vector<uint8_t> &packet) {
-  // This would handle responses from the display panel
-  // For now, we mainly inject button presses, so this is less critical
-  forward_packet_(packet);
-}
+// =============================================================================
+// 6-WIRE TYPE2 PROTOCOL HANDLER
+// =============================================================================
 
-// Send a button press to the CIO
-void BestwaySpa::send_button_press_(ButtonCode button) {
-  uint8_t packet[2];
-  packet[0] = (button >> 8) & 0xFF;
-  packet[1] = button & 0xFF;
-  
-  ESP_LOGD(TAG, "Sending button: 0x%04X", button);
-  write_array(packet, 2);
-  flush();
-  
-  last_button_code_ = button;
-}
+void BestwaySpa::handle_6wire_type2_protocol_() {
+  uint32_t now = millis();
 
-// Forward packet through (man-in-the-middle passthrough)
-void BestwaySpa::forward_packet_(const std::vector<uint8_t> &packet) {
-  if (!packet.empty()) {
-    write_array(packet.data(), packet.size());
-    flush();
+  // Refresh DSP display at regular intervals
+  if (now - last_dsp_refresh_ >= DSP_REFRESH_INTERVAL_MS) {
+    send_dsp_payload_type2_();
+    last_dsp_refresh_ = now;
+  }
+
+  // Poll for button presses at regular intervals
+  if (now - last_button_poll_ >= BUTTON_POLL_INTERVAL_MS) {
+    receive_cio_payload_type2_();
+    update_states_from_payload_();
+    last_button_poll_ = now;
   }
 }
 
-// Update climate state from spa state
+void BestwaySpa::send_dsp_payload_type2_() {
+  if (cs_pin_ == nullptr || clk_pin_ == nullptr || data_pin_ == nullptr) {
+    ESP_LOGW(TAG, "6-wire pins not configured");
+    return;
+  }
+
+  // Set data pin to output mode
+  data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+
+  // Start transmission - CS low
+  cs_pin_->digital_write(false);
+  delayMicroseconds(10);
+
+  // Send command byte 1
+  send_bits_to_dsp_(TYPE2_CMD1, 8);
+
+  // Send 5-byte payload (LSB first for TYPE2)
+  for (size_t i = 0; i < 5; i++) {
+    // TYPE2 sends LSB first
+    uint8_t byte = dsp_payload_[i];
+    for (int bit = 0; bit < 8; bit++) {
+      data_pin_->digital_write((byte >> bit) & 0x01);
+      pulse_clock_();
+    }
+  }
+
+  // End transmission - CS high
+  cs_pin_->digital_write(true);
+  delayMicroseconds(10);
+
+  // Send brightness command
+  cs_pin_->digital_write(false);
+  send_bits_to_dsp_(TYPE2_CMD3 | (state_.brightness & 0x07), 8);
+  cs_pin_->digital_write(true);
+}
+
+void BestwaySpa::receive_cio_payload_type2_() {
+  if (cs_pin_ == nullptr || clk_pin_ == nullptr || data_pin_ == nullptr) {
+    return;
+  }
+
+  // Send command to request button state
+  data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+
+  cs_pin_->digital_write(false);
+  delayMicroseconds(10);
+
+  // Send data read command
+  send_bits_to_dsp_(TYPE2_CMD2, 8);
+
+  // Switch to input mode
+  data_pin_->pin_mode(gpio::FLAG_INPUT);
+  delayMicroseconds(10);
+
+  // Read 16-bit button code (LSB first for TYPE2)
+  uint16_t button_code = 0;
+  for (int bit = 0; bit < 16; bit++) {
+    pulse_clock_();
+    if (data_pin_->digital_read()) {
+      button_code |= (1 << bit);
+    }
+  }
+
+  // End transmission
+  cs_pin_->digital_write(true);
+
+  // Store button code if valid
+  if (button_code != 0x0000) {
+    current_button_code_ = button_code;
+    ESP_LOGV(TAG, "6-wire TYPE2 button code: 0x%04X", button_code);
+  }
+}
+
+// =============================================================================
+// 6-WIRE BIT-BANGING HELPERS
+// =============================================================================
+
+void BestwaySpa::send_bits_to_dsp_(uint32_t data, uint8_t bits) {
+  // Send MSB first (TYPE1 style)
+  for (int i = bits - 1; i >= 0; i--) {
+    data_pin_->digital_write((data >> i) & 0x01);
+    pulse_clock_();
+  }
+}
+
+uint16_t BestwaySpa::receive_bits_from_dsp_(uint8_t bits) {
+  uint16_t result = 0;
+
+  // Read MSB first (TYPE1 style)
+  for (int i = bits - 1; i >= 0; i--) {
+    pulse_clock_();
+    if (data_pin_->digital_read()) {
+      result |= (1 << i);
+    }
+  }
+
+  return result;
+}
+
+void BestwaySpa::pulse_clock_(uint32_t duration_us) {
+  clk_pin_->digital_write(true);
+  delayMicroseconds(duration_us);
+  clk_pin_->digital_write(false);
+  delayMicroseconds(duration_us);
+}
+
+// =============================================================================
+// STATE MANAGEMENT
+// =============================================================================
+
+void BestwaySpa::update_states_from_payload_() {
+  // Decode button press from current_button_code_
+  const uint16_t *btn_codes;
+  switch (model_) {
+    case MODEL_PRE2021:
+      btn_codes = BTN_CODES_PRE2021;
+      break;
+    case MODEL_P05504:
+      btn_codes = BTN_CODES_P05504;
+      break;
+    case MODEL_54149E:
+      btn_codes = BTN_CODES_54149E;
+      break;
+    default:
+      btn_codes = BTN_CODES_PRE2021;
+      break;
+  }
+
+  // Find which button was pressed
+  for (uint8_t i = 0; i < BTN_COUNT; i++) {
+    if (current_button_code_ == btn_codes[i] && i != NOBTN) {
+      ESP_LOGD(TAG, "Button pressed: %d", i);
+      switch (i) {
+        case LOCK:
+          state_.locked = !state_.locked;
+          break;
+        case POWER:
+          state_.power = !state_.power;
+          break;
+        case HEAT:
+          if (!state_.locked && state_.power) {
+            state_.heater_enabled = !state_.heater_enabled;
+          }
+          break;
+        case PUMP:
+          if (!state_.locked && state_.power) {
+            state_.filter_pump = !state_.filter_pump;
+          }
+          break;
+        case BUBBLES:
+          if (!state_.locked && state_.power) {
+            state_.bubbles = !state_.bubbles;
+          }
+          break;
+        case HYDROJETS:
+          if (!state_.locked && state_.power && has_jets()) {
+            state_.jets = !state_.jets;
+          }
+          break;
+        case UP:
+          if (!state_.locked && state_.power) {
+            state_.target_temp += 1.0f;
+            if (state_.unit_celsius && state_.target_temp > 40.0f)
+              state_.target_temp = 40.0f;
+            if (!state_.unit_celsius && state_.target_temp > 104.0f)
+              state_.target_temp = 104.0f;
+          }
+          break;
+        case DOWN:
+          if (!state_.locked && state_.power) {
+            state_.target_temp -= 1.0f;
+            if (state_.unit_celsius && state_.target_temp < 20.0f)
+              state_.target_temp = 20.0f;
+            if (!state_.unit_celsius && state_.target_temp < 68.0f)
+              state_.target_temp = 68.0f;
+          }
+          break;
+        case UNIT:
+          if (!state_.locked && state_.power) {
+            state_.unit_celsius = !state_.unit_celsius;
+            // Convert temperatures
+            if (state_.unit_celsius) {
+              state_.current_temp = fahrenheit_to_celsius_(state_.current_temp);
+              state_.target_temp = fahrenheit_to_celsius_(state_.target_temp);
+            } else {
+              state_.current_temp = celsius_to_fahrenheit_(state_.current_temp);
+              state_.target_temp = celsius_to_fahrenheit_(state_.target_temp);
+            }
+          }
+          break;
+        case TIMER:
+          if (!state_.locked && state_.power) {
+            state_.timer_active = !state_.timer_active;
+          }
+          break;
+      }
+      break;
+    }
+  }
+
+  // Reset button code
+  current_button_code_ = btn_codes[NOBTN];
+}
+
+void BestwaySpa::handle_toggles_() {
+  // Process toggle requests from Home Assistant / automation
+
+  if (toggles_.power_pressed) {
+    queue_button_(POWER, 300);
+    toggles_.power_pressed = false;
+  }
+
+  if (toggles_.lock_pressed) {
+    queue_button_(LOCK, 300);
+    toggles_.lock_pressed = false;
+  }
+
+  if (toggles_.heat_pressed) {
+    queue_button_(HEAT, 300);
+    toggles_.heat_pressed = false;
+  }
+
+  if (toggles_.pump_pressed) {
+    queue_button_(PUMP, 300);
+    toggles_.pump_pressed = false;
+  }
+
+  if (toggles_.bubbles_pressed) {
+    queue_button_(BUBBLES, 300);
+    toggles_.bubbles_pressed = false;
+  }
+
+  if (toggles_.jets_pressed && has_jets()) {
+    queue_button_(HYDROJETS, 300);
+    toggles_.jets_pressed = false;
+  }
+
+  if (toggles_.unit_pressed) {
+    queue_button_(UNIT, 300);
+    toggles_.unit_pressed = false;
+  }
+
+  if (toggles_.timer_pressed) {
+    queue_button_(TIMER, 300);
+    toggles_.timer_pressed = false;
+  }
+
+  // Handle temperature adjustment
+  if (toggles_.set_target_temp && toggles_.target_temp_delta != 0) {
+    Buttons btn = toggles_.target_temp_delta > 0 ? UP : DOWN;
+    int steps = abs(toggles_.target_temp_delta);
+    for (int i = 0; i < steps; i++) {
+      queue_button_(btn, 300);
+    }
+    toggles_.target_temp_delta = 0;
+    toggles_.set_target_temp = false;
+  }
+}
+
 void BestwaySpa::update_climate_state_() {
   // Update current temperature
   this->current_temperature = state_.current_temp;
   this->target_temperature = state_.target_temp;
-  
-  // Determine mode based on heater and filter state
-  if (!state_.heater && !state_.filter) {
+
+  // Determine mode based on state
+  if (!state_.power) {
     this->mode = climate::CLIMATE_MODE_OFF;
     this->action = climate::CLIMATE_ACTION_OFF;
-  } else if (state_.heater) {
+  } else if (state_.heater_enabled) {
     this->mode = climate::CLIMATE_MODE_HEAT;
-    
-    if (state_.heating_active) {
+
+    if (state_.heater_red) {
       this->action = climate::CLIMATE_ACTION_HEATING;
+    } else if (state_.heater_green) {
+      this->action = climate::CLIMATE_ACTION_IDLE;
     } else {
       this->action = climate::CLIMATE_ACTION_IDLE;
     }
-  } else if (state_.filter) {
+  } else if (state_.filter_pump) {
     this->mode = climate::CLIMATE_MODE_FAN_ONLY;
     this->action = climate::CLIMATE_ACTION_FAN;
+  } else {
+    this->mode = climate::CLIMATE_MODE_OFF;
+    this->action = climate::CLIMATE_ACTION_IDLE;
   }
-  
+
   this->publish_state();
 }
 
-// Update all sensors
 void BestwaySpa::update_sensors_() {
   if (current_temp_sensor_ != nullptr) {
     current_temp_sensor_->publish_state(state_.current_temp);
   }
-  
+
   if (target_temp_sensor_ != nullptr) {
     target_temp_sensor_->publish_state(state_.target_temp);
   }
-  
+
   if (heating_sensor_ != nullptr) {
-    heating_sensor_->publish_state(state_.heating_active);
+    heating_sensor_->publish_state(state_.heater_red);
   }
-  
+
   if (filter_sensor_ != nullptr) {
-    filter_sensor_->publish_state(state_.filter);
+    filter_sensor_->publish_state(state_.filter_pump);
   }
-  
+
   if (bubbles_sensor_ != nullptr) {
     bubbles_sensor_->publish_state(state_.bubbles);
   }
-  
+
+  if (jets_sensor_ != nullptr) {
+    jets_sensor_->publish_state(state_.jets);
+  }
+
   if (locked_sensor_ != nullptr) {
     locked_sensor_->publish_state(state_.locked);
   }
-  
+
+  if (power_sensor_ != nullptr) {
+    power_sensor_->publish_state(state_.power);
+  }
+
   if (error_sensor_ != nullptr) {
     error_sensor_->publish_state(state_.error_code != 0);
   }
-  
-  if (error_text_sensor_ != nullptr && state_.error_code != 0) {
-    char error_str[8];
-    snprintf(error_str, sizeof(error_str), "E%02d", state_.error_code);
-    error_text_sensor_->publish_state(error_str);
-  } else if (error_text_sensor_ != nullptr) {
-    error_text_sensor_->publish_state("OK");
+
+  if (error_text_sensor_ != nullptr) {
+    if (state_.error_code != 0) {
+      char error_str[8];
+      snprintf(error_str, sizeof(error_str), "E%02d", state_.error_code);
+      error_text_sensor_->publish_state(error_str);
+    } else {
+      error_text_sensor_->publish_state("OK");
+    }
+  }
+
+  if (display_text_sensor_ != nullptr) {
+    display_text_sensor_->publish_state(std::string(state_.display_chars));
   }
 }
 
-// Control methods
+// =============================================================================
+// BUTTON QUEUE FOR 6-WIRE
+// =============================================================================
+
+void BestwaySpa::queue_button_(Buttons button, int duration_ms) {
+  if (!button_enabled_[button]) {
+    ESP_LOGD(TAG, "Button %d is disabled", button);
+    return;
+  }
+
+  ButtonQueueItem item;
+  item.button_code = get_button_code_(button);
+  item.duration_ms = duration_ms;
+  item.start_time = 0;  // Will be set when processing starts
+  item.target_state = 0xFF;  // Don't wait for state change
+  item.target_value = 0;
+
+  button_queue_.push_back(item);
+  ESP_LOGD(TAG, "Queued button %d (code 0x%04X) for %dms", button, item.button_code, duration_ms);
+}
+
+void BestwaySpa::process_button_queue_() {
+  if (button_queue_.empty()) {
+    current_button_code_ = get_button_code_(NOBTN);
+    return;
+  }
+
+  uint32_t now = millis();
+  auto &item = button_queue_.front();
+
+  if (item.start_time == 0) {
+    // Start pressing this button
+    item.start_time = now;
+    current_button_code_ = item.button_code;
+    ESP_LOGV(TAG, "Started pressing button 0x%04X", item.button_code);
+  }
+
+  // Check if button press duration has elapsed
+  if ((now - item.start_time) >= (uint32_t)item.duration_ms) {
+    ESP_LOGV(TAG, "Finished pressing button 0x%04X", item.button_code);
+    button_queue_.erase(button_queue_.begin());
+  }
+}
+
+uint16_t BestwaySpa::get_button_code_(Buttons button) {
+  if (button >= BTN_COUNT) {
+    return 0x1B1B;
+  }
+
+  switch (model_) {
+    case MODEL_PRE2021:
+      return BTN_CODES_PRE2021[button];
+    case MODEL_P05504:
+      return BTN_CODES_P05504[button];
+    case MODEL_54149E:
+      return BTN_CODES_54149E[button];
+    default:
+      return BTN_CODES_PRE2021[button];
+  }
+}
+
+// =============================================================================
+// CHARACTER DECODING
+// =============================================================================
+
+char BestwaySpa::decode_7segment_(uint8_t segments, bool is_type1) {
+  const uint8_t *codes = is_type1 ? CHARCODES_TYPE1 : CHARCODES_TYPE2;
+  size_t code_count = sizeof(CHARCODES_TYPE1) / sizeof(CHARCODES_TYPE1[0]);
+
+  for (size_t i = 0; i < code_count; i++) {
+    if (codes[i] == segments) {
+      return CHARS[i];
+    }
+  }
+  return '?';  // Unknown segment pattern
+}
+
+// =============================================================================
+// CONTROL METHODS
+// =============================================================================
+
+void BestwaySpa::set_power(bool state) {
+  if (state_.power != state) {
+    if (protocol_type_ == PROTOCOL_4WIRE) {
+      // 4-wire doesn't have power button - toggle via heater/pump
+      state_.power = state;
+    } else {
+      toggles_.power_pressed = true;
+    }
+    ESP_LOGD(TAG, "Requested power %s", state ? "ON" : "OFF");
+  }
+}
+
 void BestwaySpa::set_heater(bool state) {
-  if (state_.heater != state) {
-    PendingCommand cmd = {BTN_HEATER, millis(), false};
-    command_queue_.push_back(cmd);
-    ESP_LOGD(TAG, "Queued heater %s", state ? "ON" : "OFF");
+  if (state_.heater_enabled != state) {
+    if (protocol_type_ == PROTOCOL_4WIRE) {
+      state_.heater_enabled = state;
+      // For 4-wire, filter must be on for heater
+      if (state && !state_.filter_pump) {
+        state_.filter_pump = true;
+      }
+    } else {
+      toggles_.heat_pressed = true;
+    }
+    ESP_LOGD(TAG, "Requested heater %s", state ? "ON" : "OFF");
   }
 }
 
 void BestwaySpa::set_filter(bool state) {
-  if (state_.filter != state) {
-    PendingCommand cmd = {BTN_FILTER, millis(), false};
-    command_queue_.push_back(cmd);
-    ESP_LOGD(TAG, "Queued filter %s", state ? "ON" : "OFF");
+  if (state_.filter_pump != state) {
+    if (protocol_type_ == PROTOCOL_4WIRE) {
+      state_.filter_pump = state;
+      // For 4-wire, turning off filter turns off heater
+      if (!state && state_.heater_enabled) {
+        state_.heater_enabled = false;
+      }
+    } else {
+      toggles_.pump_pressed = true;
+    }
+    ESP_LOGD(TAG, "Requested filter %s", state ? "ON" : "OFF");
   }
 }
 
 void BestwaySpa::set_bubbles(bool state) {
   if (state_.bubbles != state) {
-    PendingCommand cmd = {BTN_BUBBLES, millis(), false};
-    command_queue_.push_back(cmd);
-    ESP_LOGD(TAG, "Queued bubbles %s", state ? "ON" : "OFF");
+    if (protocol_type_ == PROTOCOL_4WIRE) {
+      state_.bubbles = state;
+    } else {
+      toggles_.bubbles_pressed = true;
+    }
+    ESP_LOGD(TAG, "Requested bubbles %s", state ? "ON" : "OFF");
+  }
+}
+
+void BestwaySpa::set_jets(bool state) {
+  if (!has_jets()) {
+    ESP_LOGW(TAG, "This model does not have jets");
+    return;
+  }
+
+  if (state_.jets != state) {
+    if (protocol_type_ == PROTOCOL_4WIRE) {
+      state_.jets = state;
+    } else {
+      toggles_.jets_pressed = true;
+    }
+    ESP_LOGD(TAG, "Requested jets %s", state ? "ON" : "OFF");
   }
 }
 
 void BestwaySpa::set_lock(bool state) {
   if (state_.locked != state) {
-    PendingCommand cmd = {BTN_LOCK, millis(), false};
-    command_queue_.push_back(cmd);
-    ESP_LOGD(TAG, "Queued lock %s", state ? "ON" : "OFF");
+    if (protocol_type_ == PROTOCOL_4WIRE) {
+      state_.locked = state;
+    } else {
+      toggles_.lock_pressed = true;
+    }
+    ESP_LOGD(TAG, "Requested lock %s", state ? "ON" : "OFF");
   }
 }
 
 void BestwaySpa::set_unit(bool celsius) {
   if (state_.unit_celsius != celsius) {
-    PendingCommand cmd = {BTN_UNIT, millis(), false};
-    command_queue_.push_back(cmd);
-    ESP_LOGD(TAG, "Queued unit toggle to %s", celsius ? "C" : "F");
+    if (protocol_type_ == PROTOCOL_4WIRE) {
+      state_.unit_celsius = celsius;
+      // Convert temperatures
+      if (celsius) {
+        state_.current_temp = fahrenheit_to_celsius_(state_.current_temp);
+        state_.target_temp = fahrenheit_to_celsius_(state_.target_temp);
+      } else {
+        state_.current_temp = celsius_to_fahrenheit_(state_.current_temp);
+        state_.target_temp = celsius_to_fahrenheit_(state_.target_temp);
+      }
+    } else {
+      toggles_.unit_pressed = true;
+    }
+    ESP_LOGD(TAG, "Requested unit %s", celsius ? "C" : "F");
+  }
+}
+
+void BestwaySpa::set_target_temp(float temp) {
+  // Calculate delta from current target
+  float delta = temp - state_.target_temp;
+  int8_t steps = (int8_t)roundf(delta);
+
+  if (steps != 0) {
+    adjust_target_temp(steps);
   }
 }
 
 void BestwaySpa::adjust_target_temp(int8_t delta) {
-  ButtonCode button = delta > 0 ? BTN_TEMP_UP : BTN_TEMP_DOWN;
-  int8_t steps = abs(delta);
-  
-  for (int8_t i = 0; i < steps; i++) {
-    PendingCommand cmd = {button, millis() + (i * 200), false};
-    command_queue_.push_back(cmd);
+  if (delta == 0) return;
+
+  if (protocol_type_ == PROTOCOL_4WIRE) {
+    // For 4-wire, directly adjust target
+    state_.target_temp += delta;
+    if (state_.unit_celsius) {
+      if (state_.target_temp < 20.0f) state_.target_temp = 20.0f;
+      if (state_.target_temp > 40.0f) state_.target_temp = 40.0f;
+    } else {
+      if (state_.target_temp < 68.0f) state_.target_temp = 68.0f;
+      if (state_.target_temp > 104.0f) state_.target_temp = 104.0f;
+    }
+  } else {
+    // For 6-wire, queue button presses
+    toggles_.set_target_temp = true;
+    toggles_.target_temp_delta = delta;
   }
-  
-  ESP_LOGD(TAG, "Queued %d temperature %s steps", steps, delta > 0 ? "up" : "down");
+
+  ESP_LOGD(TAG, "Adjusting target temperature by %d steps", delta);
+}
+
+void BestwaySpa::set_timer(uint8_t hours) {
+  ESP_LOGD(TAG, "Setting timer to %d hours", hours);
+  // Timer is typically just toggle on 6-wire
+  if (protocol_type_ != PROTOCOL_4WIRE) {
+    toggles_.timer_pressed = true;
+  }
+  state_.timer_hours = hours;
+}
+
+void BestwaySpa::set_brightness(uint8_t level) {
+  if (level > 8) level = 8;
+  state_.brightness = level;
+  ESP_LOGD(TAG, "Set brightness to %d", level);
+}
+
+// =============================================================================
+// STATE GETTERS
+// =============================================================================
+
+bool BestwaySpa::has_jets() const {
+  switch (model_) {
+    case MODEL_54138:
+    case MODEL_54144:
+    case MODEL_54173:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool BestwaySpa::has_air() const {
+  switch (model_) {
+    case MODEL_PRE2021:
+    case MODEL_54138:
+    case MODEL_54173:
+    case MODEL_54149E:
+    case MODEL_P05504:
+      return true;
+    case MODEL_54123:
+    case MODEL_54144:
+    case MODEL_54154:
+      return false;
+    default:
+      return true;
+  }
+}
+
+// =============================================================================
+// UTILITIES
+// =============================================================================
+
+uint8_t BestwaySpa::calculate_checksum_(const uint8_t *data, size_t len) {
+  uint8_t sum = 0;
+  for (size_t i = 0; i < len; i++) {
+    sum += data[i];
+  }
+  return sum;
 }
 
 }  // namespace bestway_spa

--- a/components/bestway_spa/bestway_spa.h
+++ b/components/bestway_spa/bestway_spa.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/hal.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
@@ -12,41 +13,197 @@
 namespace esphome {
 namespace bestway_spa {
 
+// =============================================================================
+// ENUMERATIONS - Based on VisualApproach firmware
+// =============================================================================
+
 // Protocol types
 enum ProtocolType {
-  PROTOCOL_4WIRE,  // 2021+ models
-  PROTOCOL_6WIRE   // Pre-2021 models
+  PROTOCOL_4WIRE,     // 2021+ models (UART)
+  PROTOCOL_6WIRE_T1,  // Pre-2021 6-wire TYPE1 (SPI-like)
+  PROTOCOL_6WIRE_T2   // 6-wire TYPE2 (54149E)
 };
 
-// Button codes (from Visualapproach firmware)
-enum ButtonCode {
-  BTN_NONE = 0x1B1B,
-  BTN_HEATER = 0x1012,
-  BTN_FILTER = 0x1013,
-  BTN_BUBBLES = 0x1014,
-  BTN_TEMP_UP = 0x1015,
-  BTN_TEMP_DOWN = 0x1016,
-  BTN_LOCK = 0x1017,
-  BTN_UNIT = 0x1018
+// Spa model identifiers
+enum SpaModel {
+  MODEL_PRE2021,    // Pre-2021 (6-wire TYPE1)
+  MODEL_54149E,     // 6-wire TYPE2
+  MODEL_54123,      // 4-wire (NO54123)
+  MODEL_54138,      // 4-wire with jets and air
+  MODEL_54144,      // 4-wire with jets
+  MODEL_54154,      // 4-wire
+  MODEL_54173,      // 4-wire with jets and air
+  MODEL_P05504,     // 6-wire TYPE1 variant
+  MODEL_UNKNOWN
 };
 
-// State flags (from Visualapproach STATE bits)
+// Button indices - matches VisualApproach
+enum Buttons : uint8_t {
+  NOBTN = 0,
+  LOCK,
+  TIMER,
+  BUBBLES,
+  UNIT,
+  HEAT,
+  PUMP,
+  DOWN,
+  UP,
+  POWER,
+  HYDROJETS,
+  BTN_COUNT
+};
+
+// State indices - matches VisualApproach
+enum States : uint8_t {
+  LOCKEDSTATE = 0,
+  POWERSTATE,
+  UNITSTATE,
+  BUBBLESSTATE,
+  HEATGRNSTATE,
+  HEATREDSTATE,
+  HEATSTATE,
+  PUMPSTATE,
+  CHAR1,
+  CHAR2,
+  CHAR3,
+  JETSSTATE,
+  GODSTATE,
+  TIMERSTATE,
+  STATE_COUNT
+};
+
+// =============================================================================
+// DATA STRUCTURES
+// =============================================================================
+
+// Spa state tracking
 struct SpaState {
   bool locked = false;
   bool power = true;
-  bool heater = false;
-  bool filter = false;
+  bool heater_enabled = false;
+  bool heater_green = false;     // Ready to heat
+  bool heater_red = false;       // Actively heating
+  bool filter_pump = false;
   bool bubbles = false;
-  bool heating_active = false;  // RED LED
-  bool heating_ready = false;   // GRN LED
-  bool unit_celsius = false;
+  bool jets = false;
+  bool unit_celsius = true;
+  bool timer_active = false;
+  uint8_t timer_hours = 0;
   uint8_t error_code = 0;
-  
+
   float current_temp = 20.0;
   float target_temp = 37.0;
-  
+
   uint8_t brightness = 8;
+
+  // Raw display characters
+  char display_chars[4] = {' ', ' ', ' ', '\0'};
 };
+
+// Toggle requests
+struct SpaToggles {
+  bool power_pressed = false;
+  bool lock_pressed = false;
+  bool timer_pressed = false;
+  bool bubbles_pressed = false;
+  bool jets_pressed = false;
+  bool heat_pressed = false;
+  bool pump_pressed = false;
+  bool up_pressed = false;
+  bool down_pressed = false;
+  bool unit_pressed = false;
+
+  bool set_target_temp = false;
+  int8_t target_temp_delta = 0;
+};
+
+// Button queue item for 6-wire protocol
+struct ButtonQueueItem {
+  uint16_t button_code;
+  uint8_t target_state;
+  int target_value;
+  int duration_ms;
+  uint32_t start_time;
+};
+
+// =============================================================================
+// 7-SEGMENT DISPLAY CHARACTER CODES
+// =============================================================================
+
+// 7-segment character codes for TYPE1 (38 characters)
+static const uint8_t CHARCODES_TYPE1[] = {
+  0x7F, 0x0D, 0xB7, 0x9F, 0xCD, 0xDB, 0xFB, 0x0F, 0xFF, 0xDF,  // 0-9
+  0xEF, 0xF9, 0x73, 0xBD, 0xF3, 0xE3, 0x7B, 0xE9, 0x09, 0x3D,  // A-J
+  0xE1, 0x71, 0x49, 0xA9, 0xB9, 0xE7, 0xCF, 0xA1, 0xDB, 0xF1,  // K-T
+  0x7D, 0x7D, 0x7D, 0xED, 0xDD, 0xB7, 0x00, 0x80              // U-Z, space, dash
+};
+
+// 7-segment character codes for TYPE2
+static const uint8_t CHARCODES_TYPE2[] = {
+  0x3F, 0x06, 0x5B, 0x4F, 0x66, 0x6D, 0x7D, 0x07, 0x7F, 0x6F,  // 0-9
+  0x77, 0x7C, 0x39, 0x5E, 0x79, 0x71, 0x3D, 0x76, 0x06, 0x0E,  // A-J
+  0x70, 0x38, 0x15, 0x54, 0x5C, 0x73, 0x67, 0x50, 0x6D, 0x78,  // K-T
+  0x3E, 0x3E, 0x3E, 0x76, 0x6E, 0x5B, 0x00, 0x40              // U-Z, space, dash
+};
+
+// Character lookup table
+static const char CHARS[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ -";
+
+// =============================================================================
+// BUTTON CODES BY MODEL
+// =============================================================================
+
+// Button codes for PRE2021 (6-wire TYPE1)
+// Index: NOBTN, LOCK, TIMER, BUBBLES, UNIT, HEAT, PUMP, DOWN, UP, POWER, JETS
+static const uint16_t BTN_CODES_PRE2021[] = {
+  0x1B1B, 0x0200, 0x0100, 0x0300, 0x1012, 0x1212, 0x1112, 0x1312, 0x0809, 0x0000, 0x0000
+};
+
+// Button codes for P05504 (6-wire TYPE1 variant)
+static const uint16_t BTN_CODES_P05504[] = {
+  0x1B1B, 0x0210, 0x0110, 0x0310, 0x1022, 0x1222, 0x1122, 0x1322, 0x081A, 0x0000, 0x0000
+};
+
+// Button codes for MODEL54149E (6-wire TYPE2)
+static const uint16_t BTN_CODES_54149E[] = {
+  0x0000, 0x0080, 0x0040, 0x0020, 0x0010, 0x0008, 0x0004, 0x0002, 0x0001, 0x0100, 0x0200
+};
+
+// =============================================================================
+// 4-WIRE MODEL CONFIGURATIONS
+// =============================================================================
+
+// Heater bitmasks for 4-wire models
+struct ModelConfig4W {
+  uint8_t heat_bitmask1;
+  uint8_t heat_bitmask2;
+  uint8_t pump_bitmask;
+  uint8_t bubbles_bitmask;
+  uint8_t jets_bitmask;
+  bool has_jets;
+  bool has_air;
+};
+
+// Model configurations
+static const ModelConfig4W CONFIG_54123 = {0x02, 0x08, 0x04, 0x10, 0x00, false, false};
+static const ModelConfig4W CONFIG_54138 = {0x30, 0x40, 0x04, 0x08, 0x80, true, true};
+static const ModelConfig4W CONFIG_54144 = {0x30, 0x40, 0x04, 0x08, 0x80, true, false};
+static const ModelConfig4W CONFIG_54154 = {0x02, 0x08, 0x04, 0x10, 0x00, false, false};
+static const ModelConfig4W CONFIG_54173 = {0x30, 0x40, 0x04, 0x08, 0x80, true, true};
+
+// =============================================================================
+// MAIN SPA CLASS
+// =============================================================================
+
+class BestwaySpa;
+
+// Forward declarations for switches
+class BestwaySpaHeaterSwitch;
+class BestwaySpaFilterSwitch;
+class BestwaySpaBubblesSwitch;
+class BestwaySpaJetsSwitch;
+class BestwaySpaLockSwitch;
+class BestwaySpaPowerSwitch;
 
 class BestwaySpa : public climate::Climate, public uart::UARTDevice, public Component {
  public:
@@ -54,98 +211,170 @@ class BestwaySpa : public climate::Climate, public uart::UARTDevice, public Comp
   void loop() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
-  
+
   // Climate interface
   climate::ClimateTraits traits() override;
   void control(const climate::ClimateCall &call) override;
-  
-  // Configuration
+
+  // Configuration setters
   void set_protocol_type(ProtocolType type) { protocol_type_ = type; }
-  
+  void set_model(SpaModel model) { model_ = model; }
+
+  // 6-wire pin configuration
+  void set_clk_pin(InternalGPIOPin *pin) { clk_pin_ = pin; }
+  void set_data_pin(InternalGPIOPin *pin) { data_pin_ = pin; }
+  void set_cs_pin(InternalGPIOPin *pin) { cs_pin_ = pin; }
+  void set_audio_pin(InternalGPIOPin *pin) { audio_pin_ = pin; }
+
   // Sensors
   void set_current_temperature_sensor(sensor::Sensor *sensor) { current_temp_sensor_ = sensor; }
   void set_target_temperature_sensor(sensor::Sensor *sensor) { target_temp_sensor_ = sensor; }
-  
+
   // Binary sensors
   void set_heating_sensor(binary_sensor::BinarySensor *sensor) { heating_sensor_ = sensor; }
   void set_filter_sensor(binary_sensor::BinarySensor *sensor) { filter_sensor_ = sensor; }
   void set_bubbles_sensor(binary_sensor::BinarySensor *sensor) { bubbles_sensor_ = sensor; }
+  void set_jets_sensor(binary_sensor::BinarySensor *sensor) { jets_sensor_ = sensor; }
   void set_locked_sensor(binary_sensor::BinarySensor *sensor) { locked_sensor_ = sensor; }
+  void set_power_sensor(binary_sensor::BinarySensor *sensor) { power_sensor_ = sensor; }
   void set_error_sensor(binary_sensor::BinarySensor *sensor) { error_sensor_ = sensor; }
-  
-  // Text sensor
+
+  // Text sensors
   void set_error_text_sensor(text_sensor::TextSensor *sensor) { error_text_sensor_ = sensor; }
-  
-  // Control methods (called by switches)
+  void set_display_text_sensor(text_sensor::TextSensor *sensor) { display_text_sensor_ = sensor; }
+
+  // Control methods (called by switches and automation)
+  void set_power(bool state);
   void set_heater(bool state);
   void set_filter(bool state);
   void set_bubbles(bool state);
+  void set_jets(bool state);
   void set_lock(bool state);
   void set_unit(bool celsius);
+  void set_target_temp(float temp);
   void adjust_target_temp(int8_t delta);
-  
+  void set_timer(uint8_t hours);
+  void set_brightness(uint8_t level);
+
+  // State getters
+  const SpaState& get_state() const { return state_; }
+  bool has_jets() const;
+  bool has_air() const;
+  SpaModel get_model() const { return model_; }
+
  protected:
   // Protocol handlers
   void handle_4wire_protocol_();
-  void handle_6wire_protocol_();
-  
-  // Packet parsing
-  void parse_cio_to_dsp_packet_(const std::vector<uint8_t> &packet);
-  void parse_dsp_to_cio_packet_(const std::vector<uint8_t> &packet);
-  
-  // Packet sending
-  void send_button_press_(ButtonCode button);
-  void forward_packet_(const std::vector<uint8_t> &packet);
-  
+  void handle_6wire_type1_protocol_();
+  void handle_6wire_type2_protocol_();
+
+  // 6-wire SPI-like bit-banging
+  void send_bits_to_dsp_(uint32_t data, uint8_t bits);
+  uint16_t receive_bits_from_dsp_(uint8_t bits);
+  void pulse_clock_(uint32_t duration_us = 50);
+
+  // 6-wire packet handling
+  void send_dsp_payload_type1_();
+  void send_dsp_payload_type2_();
+  void receive_cio_payload_type1_();
+  void receive_cio_payload_type2_();
+  uint16_t get_pressed_button_();
+
+  // 4-wire packet handling
+  void parse_4wire_packet_(const std::vector<uint8_t> &packet);
+  void send_4wire_response_();
+
   // State management
+  void update_states_from_payload_();
+  void handle_toggles_();
   void update_climate_state_();
   void update_sensors_();
-  void publish_state_();
-  
+
+  // Button queue for 6-wire
+  void queue_button_(Buttons button, int duration_ms = 300);
+  void process_button_queue_();
+  uint16_t get_button_code_(Buttons button);
+
+  // Character decoding
+  char decode_7segment_(uint8_t segments, bool is_type1);
+
   // Utilities
   float celsius_to_fahrenheit_(float c) { return c * 9.0f / 5.0f + 32.0f; }
   float fahrenheit_to_celsius_(float f) { return (f - 32.0f) * 5.0f / 9.0f; }
-  
+  uint8_t calculate_checksum_(const uint8_t *data, size_t len);
+
+  // Configuration
   ProtocolType protocol_type_{PROTOCOL_4WIRE};
+  SpaModel model_{MODEL_54154};
+
+  // GPIO pins for 6-wire
+  InternalGPIOPin *clk_pin_{nullptr};
+  InternalGPIOPin *data_pin_{nullptr};
+  InternalGPIOPin *cs_pin_{nullptr};
+  InternalGPIOPin *audio_pin_{nullptr};
+
+  // State
   SpaState state_;
-  
+  SpaToggles toggles_;
+
   // Sensors
   sensor::Sensor *current_temp_sensor_{nullptr};
   sensor::Sensor *target_temp_sensor_{nullptr};
   binary_sensor::BinarySensor *heating_sensor_{nullptr};
   binary_sensor::BinarySensor *filter_sensor_{nullptr};
   binary_sensor::BinarySensor *bubbles_sensor_{nullptr};
+  binary_sensor::BinarySensor *jets_sensor_{nullptr};
   binary_sensor::BinarySensor *locked_sensor_{nullptr};
+  binary_sensor::BinarySensor *power_sensor_{nullptr};
   binary_sensor::BinarySensor *error_sensor_{nullptr};
   text_sensor::TextSensor *error_text_sensor_{nullptr};
-  
+  text_sensor::TextSensor *display_text_sensor_{nullptr};
+
   // Packet buffers
   std::vector<uint8_t> rx_buffer_;
-  std::vector<uint8_t> packet_buffer_;
-  
+  uint8_t cio_payload_[16]{0};
+  uint8_t dsp_payload_[16]{0};
+  size_t cio_payload_len_{0};
+  size_t dsp_payload_len_{0};
+
   // Timing
   uint32_t last_packet_time_{0};
   uint32_t last_state_update_{0};
   uint32_t last_sensor_update_{0};
-  
-  // Command queue
-  struct PendingCommand {
-    ButtonCode button;
-    uint32_t time;
-    bool processed;
-  };
-  std::vector<PendingCommand> command_queue_;
-  
+  uint32_t last_dsp_refresh_{0};
+  uint32_t last_button_poll_{0};
+
+  // Button queue
+  std::vector<ButtonQueueItem> button_queue_;
+  uint16_t current_button_code_{0};
+  bool button_enabled_[BTN_COUNT]{true, true, true, true, true, true, true, true, true, true, true};
+
   // Protocol state
+  bool paused_{false};
+  bool new_packet_available_{false};
+  uint8_t bit_counter_{0};
+  uint8_t byte_buffer_{0};
+
+  // 4-wire state
   bool waiting_for_response_{false};
-  uint16_t last_button_code_{BTN_NONE};
+  uint8_t heater_stage_{0};
+  uint32_t stage_start_time_{0};
+
+  // Model config
+  const ModelConfig4W *model_config_{&CONFIG_54154};
 };
 
-// Switch implementations
+// =============================================================================
+// SWITCH IMPLEMENTATIONS
+// =============================================================================
+
 class BestwaySpaHeaterSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(BestwaySpa *parent) { parent_ = parent; }
-  void write_state(bool state) override { parent_->set_heater(state); }
+  void write_state(bool state) override {
+    parent_->set_heater(state);
+    publish_state(state);
+  }
  protected:
   BestwaySpa *parent_{nullptr};
 };
@@ -153,7 +382,10 @@ class BestwaySpaHeaterSwitch : public switch_::Switch, public Component {
 class BestwaySpaFilterSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(BestwaySpa *parent) { parent_ = parent; }
-  void write_state(bool state) override { parent_->set_filter(state); }
+  void write_state(bool state) override {
+    parent_->set_filter(state);
+    publish_state(state);
+  }
  protected:
   BestwaySpa *parent_{nullptr};
 };
@@ -161,7 +393,23 @@ class BestwaySpaFilterSwitch : public switch_::Switch, public Component {
 class BestwaySpaBubblesSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(BestwaySpa *parent) { parent_ = parent; }
-  void write_state(bool state) override { parent_->set_bubbles(state); }
+  void write_state(bool state) override {
+    parent_->set_bubbles(state);
+    publish_state(state);
+  }
+ protected:
+  BestwaySpa *parent_{nullptr};
+};
+
+class BestwaySpaJetsSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(BestwaySpa *parent) { parent_ = parent; }
+  void write_state(bool state) override {
+    if (parent_->has_jets()) {
+      parent_->set_jets(state);
+      publish_state(state);
+    }
+  }
  protected:
   BestwaySpa *parent_{nullptr};
 };
@@ -169,7 +417,21 @@ class BestwaySpaBubblesSwitch : public switch_::Switch, public Component {
 class BestwaySpaLockSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(BestwaySpa *parent) { parent_ = parent; }
-  void write_state(bool state) override { parent_->set_lock(state); }
+  void write_state(bool state) override {
+    parent_->set_lock(state);
+    publish_state(state);
+  }
+ protected:
+  BestwaySpa *parent_{nullptr};
+};
+
+class BestwaySpaPowerSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(BestwaySpa *parent) { parent_ = parent; }
+  void write_state(bool state) override {
+    parent_->set_power(state);
+    publish_state(state);
+  }
  protected:
   BestwaySpa *parent_{nullptr};
 };


### PR DESCRIPTION
This is a major update that adds full support for all Bestway spa models using both 4-wire UART and 6-wire SPI-like protocols.

## New Features

### Protocol Support
- 6-wire TYPE1 protocol (PRE2021, P05504 models)
- 6-wire TYPE2 protocol (54149E model)
- Full SPI-like bit-banging implementation
- Proper button code handling for each model variant

### Model Support
- 4-wire models: 54123, 54138, 54144, 54154, 54173
- 6-wire TYPE1: PRE2021, P05504
- 6-wire TYPE2: 54149E
- Model-specific features (jets, air bubbles)
- Dual-stage heater control

### New Controls
- Power switch
- Jets switch (for models with hydrojets)
- All button codes from VisualApproach firmware

### New Sensors
- Power status binary sensor
- Jets status binary sensor
- Display text sensor

## Technical Details

Based on VisualApproach WiFi-remote-for-Bestway-Lay-Z-SPA:
- CIO_TYPE1/CIO_TYPE2 protocol implementations
- DSP_TYPE1/DSP_TYPE2 display protocols
- 7-segment character decoding
- Button queue system for 6-wire protocols
- Proper CLK/DATA/CS pin handling

## Configuration

6-wire models now require additional pin configuration:
- clk_pin: Clock signal
- data_pin: Bidirectional data
- cs_pin: Chip select
- audio_pin: Optional buzzer

See README.md for complete configuration reference.